### PR TITLE
Re added the old Enum for FreeLook Module

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinCamera.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinCamera.java
@@ -47,7 +47,7 @@ public abstract class MixinCamera implements Global {
     @ModifyArgs(method = "update", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/Camera;setRotation(FF)V"))
     private void onUpdateSetRotationArgs(Args args) {
         FreeLook freeLook = Module.get(FreeLook.class);
-        if (freeLook.isEnabled() && mc.options.getPerspective() == freeLook.perspective.getVal()) {
+        if (freeLook.isEnabled() && mc.options.getPerspective() == freeLook.perspective.getVal().getPerspective()) {
             args.set(0, freeLook.cY);
             args.set(1, freeLook.cP);
         }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/FreeLook.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/FreeLook.java
@@ -14,10 +14,10 @@ import net.minecraft.util.math.MathHelper;
 public class FreeLook extends ListenerModule {
 
     private final SettingSection scGeneral = getGeneralSection();
-    public final ModuleSetting<Perspective> perspective = scGeneral.add(EnumSetting.create(Perspective.class)
+    public final ModuleSetting<POV> perspective = scGeneral.add(EnumSetting.create(POV.class)
             .name("camera-perspective")
             .description("The perspective which lock the camera.")
-            .def(Perspective.THIRD_PERSON_FRONT)
+            .def(POV.THIRD_PERSON_FOV)
             .build()
     );
     public final ModuleSetting<Integer> freeLookPerspective = scGeneral.add(createIntSetting()
@@ -34,6 +34,7 @@ public class FreeLook extends ListenerModule {
             .def(false)
             .build()
     );
+
     public FreeLook() {
         super("free-look", Categories.RENDER, "lock your camera perspective and let you move around it");
     }
@@ -46,11 +47,11 @@ public class FreeLook extends ListenerModule {
         if (PlayerUtils.invalid()) return;
         cY = PlayerUtils.player().getYaw();
         cP = PlayerUtils.player().getPitch();
-        if (changeToPov.getVal()) mc.options.setPerspective(perspective.getVal());
+        if (changeToPov.getVal()) mc.options.setPerspective(perspective.getVal().getPerspective());
     }
 
     @Override
-    public void onDisable(){
+    public void onDisable() {
         if (PlayerUtils.invalid()) return;
         if (changeToPov.getVal()) mc.options.setPerspective(Perspective.FIRST_PERSON);
     }
@@ -60,5 +61,21 @@ public class FreeLook extends ListenerModule {
     private void onTick(ClientTickEndEvent e) {
         PlayerUtils.player().setPitch(MathHelper.clamp(PlayerUtils.player().getPitch(), freeLookPerspective.getVal() - 180, freeLookPerspective.getVal()));
         cP = MathHelper.clamp(cP, freeLookPerspective.getVal() - 180, freeLookPerspective.getVal());
+    }
+
+    public enum POV {
+        FIRST_PERSON_FOV(Perspective.FIRST_PERSON),
+        SECOND_PERSON_FOV(Perspective.THIRD_PERSON_BACK),
+        THIRD_PERSON_FOV(Perspective.THIRD_PERSON_FRONT);
+
+        private final Perspective perspective;
+
+        POV(Perspective perspective) {
+            this.perspective = perspective;
+        }
+
+        public Perspective getPerspective() {
+            return perspective;
+        }
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

In #80 I changed the Enum for the FreeLook Module, It caused a game crash (config issues 😭), so i changed the enum to the way it was before #80 

## Related issues

**NONE**

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.

