### PR TITLE
Add invisible entity condition to scripting

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/Conditionals.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/Conditionals.java
@@ -279,6 +279,9 @@ public class Conditionals implements Global {
     // @Format (if|if_not) gliding {}
     // @Format (while|while_not) <num>? gliding {}
     public static final Conditional GLIDING;
+    // @Format (if|if_not) invisible {}
+    // @Format (while|while_not) <num>? invisible {}
+    public static final Conditional INVISIBLE;
 
 
     static {
@@ -459,5 +462,6 @@ public class Conditionals implements Global {
         SPRINTING = register("sprinting", ctx -> ctx.end(true, ctx.entity.isSprinting()));
         SWIMMING = register("swimming", ctx -> ctx.end(true, ctx.entity.isSwimming()));
         GLIDING = register("gliding", ctx -> ctx.end(true, ctx.entity instanceof PlayerEntity player && player.isGliding()));
+        INVISIBLE = register("invisible", ctx -> ctx.end(true, ctx.entity.isInvisible()));
     }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Adds a new `invisible` entity conditional to the scripting system.

This allows scripts to explicitly check whether a target entity is invisible, improving control flow for combat and utility scripts that rely on entity visibility.

Documentation has been updated to include the new conditional in:
- `if`
- `if_not`
- `while`
- `while_not`

The implementation is lightweight and uses the existing entity context (`ctx.entity.isInvisible()`), keeping behavior consistent with vanilla mechanics.

## Related issues

N/A

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder (ImproperIssues).
- [ ] I have added comments to my code in more complex areas (not required for this change).
- [x] I have tested the code in both development and production environments.
- [x] I have joined the ClickCrystals Discord.