### PR TITLE
Add directional shield toggle to AxeSwap

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/anchoring/AxeSwap.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/anchoring/AxeSwap.java
@@ -6,6 +6,8 @@ import io.github.itzispyder.clickcrystals.events.events.client.PlayerAttackEntit
 import io.github.itzispyder.clickcrystals.modrinth.ModrinthNoNo;
 import io.github.itzispyder.clickcrystals.modules.Categories;
 import io.github.itzispyder.clickcrystals.modules.Module;
+import io.github.itzispyder.clickcrystals.modules.ModuleSetting;
+import io.github.itzispyder.clickcrystals.modules.settings.BooleanSetting;
 import io.github.itzispyder.clickcrystals.util.minecraft.EntityUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.HotbarUtils;
 import net.minecraft.world.entity.player.Player;
@@ -13,6 +15,12 @@ import net.minecraft.world.item.AxeItem;
 
 @ModrinthNoNo
 public class AxeSwap extends Module implements Listener {
+
+    public final ModuleSetting<Boolean> allowBackstab = getGeneralSection().add(BooleanSetting.create()
+            .name("Directional Shield")
+            .description("Only trigger if the enemy is facing you")
+            .def(true)
+            .build());
 
     public AxeSwap() {
         super("axe-swap", Categories.PVP, "Switch to axe if hitting a shielding opponent with a sword");
@@ -30,7 +38,7 @@ public class AxeSwap extends Module implements Listener {
 
     @EventHandler
     private void onAttack(PlayerAttackEntityEvent e) {
-        if (e.getEntity() instanceof Player p && EntityUtils.isBlocking(p)) {
+        if (e.getEntity() instanceof Player p && EntityUtils.isBlocking(p, allowBackstab.getVal())) {
             if (HotbarUtils.nameContains("sword") && HotbarUtils.has(item -> item.getItem() instanceof AxeItem)) {
                 HotbarUtils.search(item -> item.getItem() instanceof AxeItem);
             }

--- a/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/Conditionals.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/Conditionals.java
@@ -2,6 +2,7 @@ package io.github.itzispyder.clickcrystals.scripting.components;
 
 import io.github.itzispyder.clickcrystals.Global;
 import io.github.itzispyder.clickcrystals.modules.Module;
+import io.github.itzispyder.clickcrystals.modules.modules.anchoring.AxeSwap;
 import io.github.itzispyder.clickcrystals.scripting.ScriptArgs;
 import io.github.itzispyder.clickcrystals.scripting.ScriptArgsReader;
 import io.github.itzispyder.clickcrystals.scripting.ScriptParser;
@@ -377,7 +378,11 @@ public class Conditionals implements Global {
         COLLIDING_VERTICALLY = register("colliding_vertically", ctx -> ctx.end(true, EntityUtils.isCollidingVertically(ctx.entity)));
         JUMPING = register("jumping", ctx -> ctx.end(true, PlayerUtils.valid() && mc.player.input.keyPresses.jump() && !mc.player.isUnderWater()));
         MOVING = register("moving", ctx -> ctx.end(true, EntityUtils.isMoving(ctx.entity)));
-        BLOCKING = register("blocking", ctx -> ctx.end(true, EntityUtils.isBlocking(ctx.entity)));
+        BLOCKING = register("blocking", ctx -> {
+            AxeSwap axeSwap = Module.get(AxeSwap.class);
+            boolean directional = axeSwap != null && axeSwap.allowBackstab.getVal();
+            return ctx.end(true, EntityUtils.isBlocking(ctx.entity, directional));
+        });
         ON_GROUND = register("on_ground", ctx -> ctx.end(true, ctx.entity.onGround()));
         ON_FIRE = register("on_fire", ctx -> ctx.end(true, ctx.entity.isOnFire()));
         FROZEN = register("frozen", ctx -> ctx.end(true, ctx.entity.isFullyFrozen()));

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/EntityUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/EntityUtils.java
@@ -48,20 +48,24 @@ public class EntityUtils implements Global {
     }
 
     public static boolean isBlocking(Entity ref) {
+        return isBlocking(ref, false);
+    }
+
+    public static boolean isBlocking(Entity ref, boolean directional) {
         if (!(ref instanceof LivingEntity liv))
             return false;
         if (!liv.isBlocking())
             return false;
-            
-        // Check if shield is facing the attacker
+        if (!directional)
+            return true;
+
+        // shield only counts if they're facing you
         if (PlayerUtils.invalid())
             return true;
-            
+
         Vec3 targetLook = liv.getLookAngle().normalize();
         Vec3 toAttacker = PlayerUtils.player().position().subtract(liv.position()).normalize();
-        double dot = targetLook.dot(toAttacker);
-        
-        return dot > 0.3; // Shield blocks if target is facing attacker
+        return targetLook.dot(toAttacker) > 0.3;
     }
 
     public static boolean isColliding(Entity ref) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added a "Directional Shield" setting to AxeSwap. When on, axe swap only triggers if the enemy is facing you. When off, it triggers regardless of direction.

Note: if_blocking in scripting also uses this setting even though its in AxeSwap

## Related issues

N/A

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined the [ClickCrystals](https://discord.com/invite/tMaShNzNtP) Discord.