### PR TITLE
Add directional shield toggle to AxeSwap

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/anchoring/AxeSwap.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/anchoring/AxeSwap.java
@@ -6,6 +6,9 @@ import io.github.itzispyder.clickcrystals.events.events.client.PlayerAttackEntit
 import io.github.itzispyder.clickcrystals.modrinth.ModrinthNoNo;
 import io.github.itzispyder.clickcrystals.modules.Categories;
 import io.github.itzispyder.clickcrystals.modules.Module;
+import io.github.itzispyder.clickcrystals.modules.ModuleSetting;
+import io.github.itzispyder.clickcrystals.modules.settings.BooleanSetting;
+import io.github.itzispyder.clickcrystals.modules.settings.DoubleSetting;
 import io.github.itzispyder.clickcrystals.util.minecraft.EntityUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.HotbarUtils;
 import net.minecraft.world.entity.player.Player;
@@ -13,6 +16,20 @@ import net.minecraft.world.item.AxeItem;
 
 @ModrinthNoNo
 public class AxeSwap extends Module implements Listener {
+
+    private final ModuleSetting<Boolean> directionalShield = getGeneralSection().add(BooleanSetting.create()
+            .name("directional-shield")
+            .description("Only swap if the enemy is facing you")
+            .def(true)
+            .build());
+
+    private final ModuleSetting<Double> shieldFov = getGeneralSection().add(DoubleSetting.create()
+            .name("shield-fov")
+            .description("Detection angle for directional shield in degrees")
+            .def(60.0)
+            .min(10.0)
+            .max(180.0)
+            .build());
 
     public AxeSwap() {
         super("axe-swap", Categories.PVP, "Switch to axe if hitting a shielding opponent with a sword");
@@ -30,7 +47,7 @@ public class AxeSwap extends Module implements Listener {
 
     @EventHandler
     private void onAttack(PlayerAttackEntityEvent e) {
-        if (e.getEntity() instanceof Player p && EntityUtils.isBlocking(p)) {
+        if (e.getEntity() instanceof Player p && EntityUtils.isBlocking(p, directionalShield.getVal(), shieldFov.getVal())) {
             if (HotbarUtils.nameContains("sword") && HotbarUtils.has(item -> item.getItem() instanceof AxeItem)) {
                 HotbarUtils.search(item -> item.getItem() instanceof AxeItem);
             }

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/EntityUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/EntityUtils.java
@@ -50,18 +50,24 @@ public class EntityUtils implements Global {
     public static boolean isBlocking(Entity ref) {
         if (!(ref instanceof LivingEntity liv))
             return false;
+        return liv.isBlocking();
+    }
+
+    public static boolean isBlocking(Entity ref, boolean directional, double fov) {
+        if (!(ref instanceof LivingEntity liv))
+            return false;
         if (!liv.isBlocking())
             return false;
-            
-        // Check if shield is facing the attacker
+        if (!directional)
+            return true;
+
+        // shield only counts if they're facing you
         if (PlayerUtils.invalid())
             return true;
-            
+
         Vec3 targetLook = liv.getLookAngle().normalize();
         Vec3 toAttacker = PlayerUtils.player().position().subtract(liv.position()).normalize();
-        double dot = targetLook.dot(toAttacker);
-        
-        return dot > 0.3; // Shield blocks if target is facing attacker
+        return targetLook.dot(toAttacker) >= Mth.cos((float)(fov * Mth.DEG_TO_RAD));
     }
 
     public static boolean isColliding(Entity ref) {


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [x] New feature

## Description

Added a "Directional Shield" setting to AxeSwap. When enabled, the swap only triggers if the enemy is facing you. When disabled, it swaps regardless of direction.

Also added a "Shield FOV" setting to control the detection angle (default 60°). Uses dot product of normalized vectors with `Math.cos(Math.toRadians(fov))` for accurate angle detection.

> Note: `if_blocking` in scripting is unaffected and behaves the same as 1.3.7

## Related issues

N/A

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined the [ClickCrystals](https://discord.com/invite/tMaShNzNtP) Discord.