### PR TITLE
Broken scripts show in UI instead of disappearing

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/client/system/ClickCrystalsSystem.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/client/system/ClickCrystalsSystem.java
@@ -180,6 +180,15 @@ public class ClickCrystalsSystem implements Serializable {
         return null;
     }
 
+    public ScriptedModule getModuleByFile(File file) {
+        if (file == null) return null;
+        for (ScriptedModule m : scriptedModules.values()) {
+            if (m.filepath.equals(file.getPath()))
+                return m;
+        }
+        return null;
+    }
+
     public void runModuleById(String id, Consumer<Module> action) {
         Module m = getModuleById(id);
         if (m != null) {
@@ -196,7 +205,9 @@ public class ClickCrystalsSystem implements Serializable {
             modules.remove(module.getClass());
         }
 
-        if (module instanceof Listener listener) {
+        boolean isFailed = module instanceof ScriptedModule sm
+                && sm.loadState == ScriptedModule.LoadState.FAILED;
+        if (!isFailed && module instanceof Listener listener) {
             removeListener(listener);
         }
         keybinds.remove(module.getData().getBind());

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/GuiElement.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/GuiElement.java
@@ -64,9 +64,10 @@ public abstract class GuiElement implements Positionable, Global {
         List<String> lines = TextUtils.wordWrap(getTooltip(), 150 - 6 - 6, 0.7F);
         int height = lines.size() * 8;
         int caret = y + 2;
-        int margin = x + 6;
+        int drawX = Math.min(x, mc.getWindow().getGuiScaledWidth() - 150);
+        int margin = drawX + 6;
 
-        RenderUtils.fillRect(context, x, y, 150, height + 2, 0xD0000000);
+        RenderUtils.fillRect(context, drawX, y, 150, height + 2, 0xD0000000);
         for (String line : lines) {
             RenderUtils.drawText(context, "§7" + line, margin, caret, 0.7F, false);
             caret += 8;

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/browsingmode/ModuleElement.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/browsingmode/ModuleElement.java
@@ -31,6 +31,8 @@ public class ModuleElement extends GuiElement {
         this.blacklisted = ModrinthSupport.active && ModrinthSupport.isBlacklisted(module);
         if (blacklisted)
             setTooltip(ModrinthSupport.warning);
+        else if (module instanceof ScriptedModule sm && sm.loadState == ScriptedModule.LoadState.FAILED)
+            setTooltip("This script has an error: " + sm.failReason + ". Middle-click to edit.");
         else if (module instanceof ScriptedModule)
             setTooltip(getTooltip().concat(", §6MIDDLE-CLICK§7 to open IDE"));
     }
@@ -67,13 +69,20 @@ public class ModuleElement extends GuiElement {
         if (blacklisted) {
             RenderUtils.fillRect(context, x, y, width, height, 0x60000000);
         }
+        if (module instanceof ScriptedModule sm && sm.loadState == ScriptedModule.LoadState.FAILED) {
+            RenderUtils.fillRect(context, x, y, width, height, 0x60000000);
+        }
     }
 
     @Override
     public void onClick(double mouseX, double mouseY, int button) {
         if (blacklisted)
             return;
-
+        if (module instanceof ScriptedModule sm && sm.loadState == ScriptedModule.LoadState.FAILED) {
+            if (button == 2)
+                mc.setScreen(new ClickScriptIDE(sm));
+            return;
+        }
         if (button == 0) {
             module.setEnabled(!module.isEnabled(), false);
         }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/ScriptedModule.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/ScriptedModule.java
@@ -11,6 +11,7 @@ import io.github.itzispyder.clickcrystals.events.events.networking.PacketSendEve
 import io.github.itzispyder.clickcrystals.events.events.world.*;
 import io.github.itzispyder.clickcrystals.modules.Categories;
 import io.github.itzispyder.clickcrystals.scripting.ClickScript;
+import io.github.itzispyder.clickcrystals.scripting.ScriptParser;
 import io.github.itzispyder.clickcrystals.scripting.syntax.listeners.*;
 import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
 import io.github.itzispyder.clickcrystals.util.misc.Timer;
@@ -26,6 +27,10 @@ import java.util.Set;
 
 public class ScriptedModule extends ListenerModule {
 
+    public enum LoadState { LOADED, FAILED }
+
+    public LoadState loadState = LoadState.LOADED;
+    public String failReason = null;
     public final List<ClickListener> clickListeners = new ArrayList<>();
     public final List<KeyListener> keyListeners = new ArrayList<>();
     public final List<MoveListener> moveListeners = new ArrayList<>();
@@ -331,7 +336,20 @@ public class ScriptedModule extends ListenerModule {
         system.printf("-> executing scripts (%s)...", total);
         for (int i = 0; i < files.size(); i++) {
             File file = files.get(i);
-            new ClickScript(file).execute();
+            ClickScript script = new ClickScript(file);
+            String error = script.tryExecute();
+
+            if (error != null) {
+                String name = file.getName().replaceFirst("\\.[^.]+$", "");
+                ScriptedModule ghost = new ScriptedModule(name, "", file);
+                ghost.loadState = LoadState.FAILED;
+                ghost.failReason = error;
+                system.addModule(ghost);
+                system.printErr("Script '" + file.getName() + "' failed to load: " + error);
+            } else {
+                new ClickScript(file).execute();
+            }
+
             system.printf("<- [%s/%s] '%s'", i + 1, total, file.getName());
         }
         system.printf("<- [done] executed (%s) scripts in %s", total, timer.end().getStampPrecise());

--- a/src/main/java/io/github/itzispyder/clickcrystals/scripting/ClickScript.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/scripting/ClickScript.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.scripting;
 import io.github.itzispyder.clickcrystals.Global;
 import io.github.itzispyder.clickcrystals.client.commands.Command;
 import io.github.itzispyder.clickcrystals.client.system.Config;
+import io.github.itzispyder.clickcrystals.modules.modules.ScriptedModule;
 import io.github.itzispyder.clickcrystals.scripting.components.CommandLine;
 import io.github.itzispyder.clickcrystals.scripting.exceptions.ScriptNotFoundException;
 import io.github.itzispyder.clickcrystals.scripting.exceptions.UnknownCommandException;
@@ -24,6 +25,8 @@ public class ClickScript implements Global {
     private final Map<String, String> functions;
     private final String path;
     private final File file;
+    private String caughtError = null;
+    private boolean dryRun = false;
 
     private ClickScript(File file, String path) {
         this.file = file;
@@ -97,6 +100,20 @@ public class ClickScript implements Global {
         }
     }
 
+    public String tryExecute() {
+        dryRun = true;
+        execute();
+        dryRun = false;
+        String error = caughtError;
+        caughtError = null;
+        if (error != null) {
+            ScriptedModule partial = system.getModuleByFile(file);
+            if (partial != null)
+                system.unloadModule(partial);
+        }
+        return error;
+    }
+
     public void execute() {
         try {
             if (!file.exists() || !(path.endsWith(".ccs") || path.endsWith(".txt"))) {
@@ -126,6 +143,10 @@ public class ClickScript implements Global {
     }
 
     public void printErrorDetails(Exception ex, String cmd) {
+        if (dryRun) {
+            caughtError = "%s: %s".formatted(ex.getClass().getSimpleName(), ex.getMessage());
+            return;
+        }
         String error = getErrorDetails(ex, cmd);
         if (PlayerUtils.invalid()) {
             system.printErr(error);
@@ -174,6 +195,10 @@ public class ClickScript implements Global {
 
     public File getFile() {
         return file;
+    }
+
+    public static boolean isRegistered(String name) {
+        return REGISTRATION.containsKey(name);
     }
 
     public static String[] collectNames() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Scripts that fail to load currently disappear from the UI entirely but still
partially run in memory. The only fix was deleting the script file.

Scripts now go through a dry run on load. If an error is caught, the script
gets marked as failed and shows in the UI with the same dark overlay as
Modrinth blacklisted modules. Hovering shows the exact error. Middle click
still opens the IDE so the user can fix it without touching the file system.

## Related issues

None

## Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [ ] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined the [ClickCrystals](https://discord.com/invite/tMaShNzNtP) Discord.
<img width="1920" height="1145" alt="ccs-bug" src="https://github.com/user-attachments/assets/6e7f6c89-2245-4f14-9a1f-7f9497152358" />
