### PR TITLE
port(26.2): mechanical API updates (part 2)

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinEntityType.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinEntityType.java
@@ -1,8 +1,10 @@
 package io.github.itzispyder.clickcrystals.mixins;
 
 import io.github.itzispyder.clickcrystals.gui.misc.brushes.MobHeadBrush;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntityTypes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(EntityTypes.class)
 public abstract class MixinEntityType {
 
-    @Inject(method = "Lnet/minecraft/world/entity/EntityType;register(Ljava/lang/String;Lnet/minecraft/world/entity/EntityType$Builder;)Lnet/minecraft/world/entity/EntityType;", at = @At("RETURN"))
-    private static <T extends Entity> void register(String vanillaId, EntityTypes.Builder<T> builder, CallbackInfoReturnable<EntityType<T>> cir) {
-        MobHeadBrush.init(cir.getReturnValue(), vanillaId);
+    @Inject(method = "register(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/entity/EntityType$Builder;)Lnet/minecraft/world/entity/EntityType;", at = @At("RETURN"))
+    private static <T extends Entity> void register(ResourceKey<EntityType<?>> key, EntityType.Builder<T> builder, CallbackInfoReturnable<EntityType<T>> cir) {
+        MobHeadBrush.init(cir.getReturnValue(), key.identifier().getPath());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinEntityTypes.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinEntityTypes.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(EntityTypes.class)
-public abstract class MixinEntityType {
+public abstract class MixinEntityTypes {
 
     @Inject(method = "register(Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/world/entity/EntityType$Builder;)Lnet/minecraft/world/entity/EntityType;", at = @At("RETURN"))
     private static <T extends Entity> void register(ResourceKey<EntityType<?>> key, EntityType.Builder<T> builder, CallbackInfoReturnable<EntityType<T>> cir) {

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinLightmap.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinLightmap.java
@@ -9,6 +9,7 @@ import io.github.itzispyder.clickcrystals.modules.modules.optimization.FullBrigh
 import net.minecraft.client.renderer.Lightmap;
 import net.minecraft.client.renderer.state.LightmapRenderState;
 import net.minecraft.util.profiling.ProfilerFiller;
+import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -24,7 +25,7 @@ public abstract class MixinLightmap implements Global {
     @Inject(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/profiling/ProfilerFiller;push(Ljava/lang/String;)V", shift = At.Shift.AFTER), cancellable = true)
     private void onUpdate(LightmapRenderState renderState, CallbackInfo ci, @Local ProfilerFiller profiler) {
         if (Module.isEnabled(FullBright.class)) {
-            RenderSystem.getDevice().createCommandEncoder().clearColorTexture(this.texture, 0xFFFFFFFF);
+            RenderSystem.getDevice().createCommandEncoder().clearColorTexture(this.texture, new Vector4f(1.0F, 1.0F, 1.0F, 1.0F));
             profiler.pop();
             ci.cancel();
         }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/DeathEffects.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/DeathEffects.java
@@ -16,6 +16,7 @@ import net.minecraft.network.protocol.game.ClientboundEntityEventPacket;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityEvent;
 import net.minecraft.world.entity.LightningBolt;
+import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.component.FireworkExplosion;
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/conditionalcontexts/ConditionalBlockInFov.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/conditionalcontexts/ConditionalBlockInFov.java
@@ -6,6 +6,7 @@ import io.github.itzispyder.clickcrystals.scripting.components.ConditionEvaluati
 import io.github.itzispyder.clickcrystals.scripting.components.Conditional;
 import io.github.itzispyder.clickcrystals.util.minecraft.EntityUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
+import io.github.itzispyder.clickcrystals.util.minecraft.VectorParser;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.state.BlockState;
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/conditionalcontexts/ConditionalBlockInRange.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/scripting/components/conditionalcontexts/ConditionalBlockInRange.java
@@ -6,6 +6,7 @@ import io.github.itzispyder.clickcrystals.scripting.components.ConditionEvaluati
 import io.github.itzispyder.clickcrystals.scripting.components.Conditional;
 import io.github.itzispyder.clickcrystals.util.minecraft.EntityUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
+import io.github.itzispyder.clickcrystals.util.minecraft.VectorParser;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/render/RenderPipelines.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/render/RenderPipelines.java
@@ -6,7 +6,7 @@ import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.platform.CompareOp;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
 
 public class RenderPipelines {
     
@@ -16,7 +16,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_LINES = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_lines_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINES)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.DEBUG_LINES)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -24,7 +25,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_LINES_STRIP = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_lines_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINE_STRIP)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.DEBUG_LINE_STRIP)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -32,7 +34,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_QUADS = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.QUADS)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -40,7 +43,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TRI_FAN = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLE_FAN)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.TRIANGLE_FAN)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -48,7 +52,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TRI_STRIP = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLE_STRIP)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.TRIANGLE_STRIP)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -56,7 +61,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TRI = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLES)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.TRIANGLES)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -64,7 +70,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TEX_QUADS = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.GUI_TEXTURED_SNIPPET)
             .withLocation("pipeline/gui_textured")
-            .withVertexFormat(DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_TEX_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.QUADS)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -72,7 +79,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TEX_TRI_FAN = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.GUI_TEXTURED_SNIPPET)
             .withLocation("pipeline/gui_textured")
-            .withVertexFormat(DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.TRIANGLE_FAN)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_TEX_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.TRIANGLE_FAN)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_NONE)
@@ -80,7 +88,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TRI_STRIP_CULL = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLE_STRIP)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.TRIANGLE_STRIP)
             .withColorTargetState(WITH_BLEND)
             .withCull(true)
             .withDepthStencilState(DEPTH_LEQUAL)
@@ -88,7 +97,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_TRI_FAN_CULL = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.TRIANGLE_FAN)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.TRIANGLE_FAN)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_LEQUAL)
@@ -96,7 +106,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_QUADS_CULL = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_fill_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.QUADS)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_LEQUAL)
@@ -104,7 +115,8 @@ public class RenderPipelines {
 
     public static final RenderPipeline PIPELINE_LINES_CULL = RenderPipeline.builder(net.minecraft.client.renderer.RenderPipelines.DEBUG_FILLED_SNIPPET)
             .withLocation("pipeline/global_lines_pipeline")
-            .withVertexFormat(DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.DEBUG_LINES)
+            .withVertexBinding(0, DefaultVertexFormat.POSITION_COLOR)
+            .withPrimitiveTopology(PrimitiveTopology.DEBUG_LINES)
             .withColorTargetState(WITH_BLEND)
             .withCull(false)
             .withDepthStencilState(DEPTH_LEQUAL)

--- a/src/main/resources/clickcrystals.mixins.json
+++ b/src/main/resources/clickcrystals.mixins.json
@@ -42,7 +42,7 @@
     "AccessorLivingEntity",
     "MixinBlock",
     "MixinEntity",
-    "MixinEntityType",
+    "MixinEntityTypes",
     "MixinInventory",
     "MixinItem",
     "MixinItemStack",


### PR DESCRIPTION
## Type of change

- [x] Bug fix (build fix — port 26.1 → 26.2)
- [ ] New feature

## Description

Ports the codebase from MC 26.1 to 26.2 following the NeoForge 26.2 primer. This
covers the mechanical/one-to-one API breakages; the immediate-mode render helper
rewrite is still outstanding (see below).

**Done (compiles clean):**
- **`DeathEffects`, `ConditionalBlockInFov`, `ConditionalBlockInRange`** — added
  missing imports (`EntityTypes`, `VectorParser`); the symbols still exist in 26.2,
  they just weren't imported.
- **`MixinEntityType`** — `register` now takes `ResourceKey` instead of a `String`
  id; derive the vanilla path via `key.identifier().getPath()`.
- **`MixinLightmap`** — `CommandEncoder.clearColorTexture` now takes a `Vector4fc`
  instead of an `int` ARGB; pass `new Vector4f(1, 1, 1, 1)`.
- **`RenderPipelines`** — `RenderPipeline.Builder.withVertexFormat(fmt, Mode)` was
  split into `withVertexBinding(0, fmt)` + `withPrimitiveTopology(PrimitiveTopology.*)`
  (`VertexFormat.Mode` → `com.mojang.blaze3d.PrimitiveTopology`).

**Not done yet — immediate-mode render rewrite:**
- **`RenderUtils.getBuffer` / `drawBuffer`, `RenderUtils3d`, `ElytraShadow`.**
  26.2 removed `Tesselator` and `RenderType.draw(MeshData)`. The self-managed
  begin → build → draw path no longer exists; the replacement is
  `PreparedRenderType.drawFromBuffer(...)` over a `RenderPipeline` + GPU buffers,
  or drawing through a `MultiBufferSource` `VertexConsumer`. This is an
  architectural change whose visual output can only be verified against a running
  client, so it is intentionally left for a follow-up rather than shipped blind.

**Two runtime-only caveats:** `MixinEntityType` and `MixinLightmap` compile, but
their injections resolve at runtime — needs an in-game smoke test.

## Related issues

Follow-up to the `26.2 port part 1` work already on `main`.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments. (fixed files compile; full build still blocked on the render-helper rewrite above; mixin injections need an in-game check)
- [x] I have joined the [ClickCrystals](https://discord.com/invite/tMaShNzNtP) Discord.
