### PR TITLE
Finish the Minecraft 26.2 rendering port

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/events/events/world/RenderWorldEvent.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/events/world/RenderWorldEvent.java
@@ -2,76 +2,51 @@ package io.github.itzispyder.clickcrystals.events.events.world;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.events.Event;
-import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
 import net.minecraft.client.Camera;
 import net.minecraft.client.DeltaTracker;
-import net.minecraft.client.player.LocalPlayer;
-import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
-import org.joml.Matrix4f;
 
 public class RenderWorldEvent extends Event {
 
-    private final PoseStack matrices;
-    private final Matrix4f rotationMatrix, projectionMatrix;
-    private final GameRenderer renderer;
-    private final DeltaTracker tickCounter;
+    private final PoseStack poseStack;
+    private final Camera camera;
+    private final DeltaTracker deltaTracker;
+    private final SubmitNodeCollector submitNodeCollector;
 
-    public RenderWorldEvent(GameRenderer renderer, Matrix4f rotationMatrix, Matrix4f projectionMatrix, DeltaTracker tickCounter) {
-        this.tickCounter = tickCounter;
-        this.renderer = renderer;
-        this.rotationMatrix = rotationMatrix;
-        this.projectionMatrix = projectionMatrix;
-        this.matrices = new PoseStack();
-        this.matrices.mulPose(rotationMatrix);
+    public RenderWorldEvent(PoseStack poseStack, Camera camera, DeltaTracker deltaTracker, SubmitNodeCollector submitNodeCollector) {
+        this.poseStack = poseStack;
+        this.camera = camera;
+        this.deltaTracker = deltaTracker;
+        this.submitNodeCollector = submitNodeCollector;
     }
 
-    public PoseStack getMatrices() {
-        return matrices;
+    public PoseStack getPoseStack() {
+        return poseStack;
     }
 
-    public DeltaTracker getTickCounter() {
-        return tickCounter;
+    public DeltaTracker getDeltaTracker() {
+        return deltaTracker;
     }
 
-    public GameRenderer getRenderer() {
-        return renderer;
-    }
-
-    public Matrix4f getRotationMatrix() {
-        return rotationMatrix;
-    }
-
-    public Matrix4f getProjectionMatrix() {
-        return projectionMatrix;
+    public SubmitNodeCollector getSubmitNodeCollector() {
+        return submitNodeCollector;
     }
 
     public Camera getCamera() {
-        return renderer.mainCamera();
+        return camera;
     }
 
-    public LocalPlayer getPlayer() {
-        return PlayerUtils.player();
+    public Vec3 getCameraRelativePosition(Vec3 position) {
+        return position.subtract(getCamera().position());
     }
 
-    public Vec3 getOffsetPos(Vec3 pos) {
-        return pos.subtract(getCamera().position());
-    }
-
-    public Vec3 getOffsetPos(BlockPos pos) {
-        var c = getCamera().position();
-        double x = pos.getX() - c.x;
-        double y = pos.getY() - c.y;
-        double z = pos.getZ() - c.z;
+    public Vec3 getCameraRelativePosition(BlockPos blockPos) {
+        Vec3 cameraPosition = getCamera().position();
+        double x = blockPos.getX() - cameraPosition.x;
+        double y = blockPos.getY() - cameraPosition.y;
+        double z = blockPos.getZ() - cameraPosition.z;
         return new Vec3(x, y, z);
-    }
-
-    public boolean valid() {
-        return PlayerUtils.valid();
-    }
-
-    public boolean invalid() {
-        return PlayerUtils.invalid();
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/events/listeners/TickEventListener.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/listeners/TickEventListener.java
@@ -33,7 +33,7 @@ public class TickEventListener implements Listener, Global {
     }
 
     @EventHandler
-    public void onRenderTick(RenderWorldEvent e) {
+    public void onRenderTick(RenderWorldEvent event) {
         system.cameraRotator.onRenderTick();
     }
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
@@ -13,8 +13,8 @@ public interface AccessorMinecraftClient {
     @Accessor("crosshairPickEntity")
     Entity accessTargetedEntity();
 
-    @Invoker("setScreen")
-    void invokeSetScreen(Screen screen);
+    @Invoker("setScreenAndShow")
+    void invokeSetScreenAndShow(Screen screen);
 
     @Invoker("startAttack")
     @SuppressWarnings("all")

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinHud.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinHud.java
@@ -1,7 +1,6 @@
 package io.github.itzispyder.clickcrystals.mixins;
 
 import io.github.itzispyder.clickcrystals.Global;
-import io.github.itzispyder.clickcrystals.gui.hud.Hud;
 import io.github.itzispyder.clickcrystals.modules.Module;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.HealthAsBar;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.NoOverlay;
@@ -9,8 +8,8 @@ import io.github.itzispyder.clickcrystals.modules.modules.rendering.NoScoreboard
 import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.Hud;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -22,8 +21,8 @@ import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
-@Mixin(Gui.class)
-public abstract class MixinGui implements Global {
+@Mixin(Hud.class)
+public abstract class MixinHud implements Global {
 
     @ModifyArgs(method = "extractArmor", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphicsExtractor;blitSprite(Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIII)V"))
     private static void renderArmor(Args args) {
@@ -72,7 +71,7 @@ public abstract class MixinGui implements Global {
     public void renderHuds(GuiGraphicsExtractor context, DeltaTracker tickCounter, CallbackInfo ci) {
         if (PlayerUtils.invalid()) return;
 
-        for (Hud hud : system.huds().values())
+        for (var hud : system.huds().values())
             if (hud.canRender()) hud.render(context, tickCounter.getGameTimeDeltaPartialTick(true));
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinItemInHandRenderer.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinItemInHandRenderer.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 @Mixin(ItemInHandRenderer.class)
 public abstract class MixinItemInHandRenderer implements Global {
 
-    @Inject(method = "renderArmWithItem", at = @At("HEAD"))
+    @Inject(method = "submitArmWithItem", at = @At("HEAD"))
     public void renderFirstPersonItemInvoke(AbstractClientPlayer player, float tickProgress, float pitch, InteractionHand hand, float swingProgress, ItemStack item, float equipProgress, PoseStack matrices, SubmitNodeCollector orderedRenderCommandQueue, int light, CallbackInfo ci) {
         ViewModel vm = Module.get(ViewModel.class);
         if (!vm.isEnabled())
@@ -57,14 +57,14 @@ public abstract class MixinItemInHandRenderer implements Global {
         }
     }
 
-    @Inject(method = "renderArmWithItem", at = @At("TAIL"))
+    @Inject(method = "submitArmWithItem", at = @At("TAIL"))
     public void renderFirstPersonItemTail(AbstractClientPlayer player, float tickProgress, float pitch, InteractionHand hand, float swingProgress, ItemStack item, float equipProgress, PoseStack matrices, SubmitNodeCollector orderedRenderCommandQueue, int light, CallbackInfo ci) {
         if (Module.isEnabled(ViewModel.class))
             matrices.popPose();
     }
 
     @ModifyArgs(
-            method = "renderArmWithItem(Lnet/minecraft/client/player/AbstractClientPlayer;FFLnet/minecraft/world/InteractionHand;FLnet/minecraft/world/item/ItemStack;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;I)V",
+            method = "submitArmWithItem(Lnet/minecraft/client/player/AbstractClientPlayer;FFLnet/minecraft/world/InteractionHand;FLnet/minecraft/world/item/ItemStack;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/SubmitNodeCollector;I)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ItemInHandRenderer;applyItemArmTransform(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/entity/HumanoidArm;F)V")
     )
     public void onApplyItemArmTransform(Args args) {

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinLevelRenderer.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinLevelRenderer.java
@@ -2,43 +2,65 @@ package io.github.itzispyder.clickcrystals.mixins;
 
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
+import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.Global;
 import io.github.itzispyder.clickcrystals.events.events.world.RenderWorldEvent;
 import io.github.itzispyder.clickcrystals.modules.Module;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.BlockOutline;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.renderer.LevelRenderer;
-import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.state.level.LevelRenderState;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(LevelRenderer.class)
 public abstract class MixinLevelRenderer implements Global {
 
-    @ModifyArgs(method = "renderHitOutline", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/ShapeRenderer;renderShape(Lcom/mojang/blaze3d/vertex/PoseStack;Lcom/mojang/blaze3d/vertex/VertexConsumer;Lnet/minecraft/world/phys/shapes/VoxelShape;DDDIF)V"))
-    public void setOutlineColor(Args args) {
-        BlockOutline bo = Module.get(BlockOutline.class);
+    @Unique
+    private DeltaTracker clickcrystals$deltaTracker;
+    @Unique
+    private Matrix4f clickcrystals$modelViewMatrix;
 
-        if (bo.isEnabled()) {
-            args.set(6, bo.color.getVal().getHexOpaque());
-        }
+    @ModifyArg(
+            method = "submitHitOutline",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/SubmitNodeCollector;submitShapeOutline(Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/world/phys/shapes/VoxelShape;Lnet/minecraft/client/renderer/rendertype/RenderType;IFZ)V",
+                    ordinal = 3
+            ),
+            index = 3
+    )
+    private int setOutlineColor(int originalColor) {
+        BlockOutline blockOutline = Module.get(BlockOutline.class);
+        return blockOutline.isEnabled() ? blockOutline.color.getVal().getHexOpaque() : originalColor;
     }
 
-    @Inject(method = "renderLevel", at = @At("TAIL"))
-    public void render(GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender, CallbackInfo ci) {
-        Matrix4f positionMatrix = new Matrix4f(modelViewMatrix);
-        Matrix4f projectionMatrix = new Matrix4f();
-        mc.gameRenderer.mainCamera().getViewRotationProjectionMatrix(projectionMatrix);
+    @Inject(method = "render", at = @At("HEAD"))
+    private void captureRenderContext(GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, CallbackInfo ci) {
+        clickcrystals$deltaTracker = deltaTracker;
+        clickcrystals$modelViewMatrix = new Matrix4f(modelViewMatrix);
+    }
 
-        RenderWorldEvent event = new RenderWorldEvent(mc.gameRenderer, positionMatrix, projectionMatrix, deltaTracker);
+    @Inject(method = "submitFeatures", at = @At("TAIL"))
+    private void submitClickCrystalsFeatures(LevelRenderState renderState, SubmitNodeCollector submitNodeCollector, boolean renderOutline, CallbackInfo ci) {
+        PoseStack poseStack = new PoseStack();
+        poseStack.mulPose(clickcrystals$modelViewMatrix);
+
+        RenderWorldEvent event = new RenderWorldEvent(
+                poseStack,
+                mc.gameRenderer.mainCamera(),
+                clickcrystals$deltaTracker,
+                submitNodeCollector
+        );
         system.eventBus.pass(event);
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinMinecraft.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinMinecraft.java
@@ -21,7 +21,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(Minecraft.class)
 public abstract class MixinMinecraft implements Global {
 
-    @Inject(method = "setScreen", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setScreenAndShow", at = @At("HEAD"), cancellable = true)
     public void set(Screen screen, CallbackInfo ci) {
         SetScreenEvent event = new SetScreenEvent(screen);
         system.eventBus.pass(event);
@@ -29,7 +29,7 @@ public abstract class MixinMinecraft implements Global {
         if (event.isCancelled()) {
             ci.cancel();
             AccessorMinecraftClient mc = (AccessorMinecraftClient) this;
-            mc.invokeSetScreen(null);
+            mc.invokeSetScreenAndShow(null);
         }
     }
 
@@ -40,7 +40,7 @@ public abstract class MixinMinecraft implements Global {
         system.eventBus.passWithCallbackInfo(cir, evt);
     }
 
-    @Inject(method = "destroy", at = @At("HEAD"))
+    @Inject(method = "close", at = @At("HEAD"))
     public void stop(CallbackInfo ci) {
         system.onClientStopping();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/Tunnel3x3.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/Tunnel3x3.java
@@ -204,13 +204,15 @@ public class Tunnel3x3 extends ListenerModule {
     }
 
     @EventHandler
-    public void render(RenderWorldEvent e) {
+    public void render(RenderWorldEvent event) {
         if (!renderBlocks.getVal())
             return;
 
+        var matrices = event.getPoseStack();
+        var submitNodeCollector = event.getSubmitNodeCollector();
         for (int i = targets.size() - 1; i >= index + 1; i--)
-            RenderUtils3d.renderBlock(e.getMatrices(), e.getOffsetPos(Vec3.atLowerCornerOf(targets.get(i))), 0x05FFFFFF);
-        RenderUtils3d.renderBlock(e.getMatrices(), e.getOffsetPos(Vec3.atLowerCornerOf(targets.get(index))), 0x05FF2020);
+            RenderUtils3d.renderBlock(matrices, submitNodeCollector, event.getCameraRelativePosition(Vec3.atLowerCornerOf(targets.get(i))), 0x05FFFFFF);
+        RenderUtils3d.renderBlock(matrices, submitNodeCollector, event.getCameraRelativePosition(Vec3.atLowerCornerOf(targets.get(index))), 0x05FF2020);
     }
 
     @EventHandler

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/ElytraShadow.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/ElytraShadow.java
@@ -1,8 +1,6 @@
 package io.github.itzispyder.clickcrystals.modules.modules.rendering;
 
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
-import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.events.EventHandler;
 import io.github.itzispyder.clickcrystals.events.events.world.RenderWorldEvent;
 import io.github.itzispyder.clickcrystals.gui.misc.Color;
@@ -13,11 +11,10 @@ import io.github.itzispyder.clickcrystals.modules.settings.SettingSection;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderLayers;
-import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils;
 import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
@@ -36,51 +33,46 @@ public class ElytraShadow extends ListenerModule {
     }
 
     @EventHandler
-    public void onWorldRender(RenderWorldEvent e) {
+    public void onWorldRender(RenderWorldEvent event) {
         Color color = this.color.getVal();
+        PoseStack matrices = event.getPoseStack();
+        SubmitNodeCollector submitNodeCollector = event.getSubmitNodeCollector();
+        Vec3 cameraPosition = event.getCamera().position();
+        float tickDelta = event.getDeltaTracker().getGameTimeDeltaPartialTick(true);
+
         for (AbstractClientPlayer player : PlayerUtils.getClientWorld().players())
             if (player.isFallFlying())
-                renderPlayerShadow(e, player, color);
+                renderPlayerShadow(matrices, submitNodeCollector, cameraPosition, MathUtils.lerpEntityPosVec(player, tickDelta), color);
     }
 
-    private void renderPlayerShadow(RenderWorldEvent e, Player ent, Color color) {
-        Vec3 pos = MathUtils.lerpEntityPosVec(ent, e.getTickCounter().getGameTimeDeltaPartialTick(true));
-        Vec3 pnt1, pnt2, pnt3, pnt4;
+    private void renderPlayerShadow(PoseStack matrices, SubmitNodeCollector submitNodeCollector, Vec3 cameraPosition, Vec3 playerPosition, Color color) {
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.QUADS, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            float rad = 1F;
+            float dTheta = Mth.PI / 16; // i chose this because mc pixels are 1/16 of a block, if ur computer lags womp womp
+            float dRad = rad / 16;
 
-        Matrix4f mat = e.getMatrices().last().pose();
-        BufferBuilder buf = RenderUtils.getBuffer(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+            for (float i = 0; i < Mth.TWO_PI; i += dTheta) {
+                for (float r = dRad; r <= rad; r += dRad) {
+                    Vec3 pnt1 = castShadowVertex(playerPosition.add(r * Mth.cos(i), 0, r * Mth.sin(i)));
+                    Vec3 pnt2 = castShadowVertex(playerPosition.add((r + dRad) * Mth.cos(i), 0, (r + dRad) * Mth.sin(i)));
+                    Vec3 pnt3 = castShadowVertex(playerPosition.add((r + dRad) * Mth.cos(i + dTheta), 0, (r + dRad) * Mth.sin(i + dTheta)));
+                    Vec3 pnt4 = castShadowVertex(playerPosition.add(r * Mth.cos(i + dTheta), 0, r * Mth.sin(i + dTheta)));
 
-        float rad = 1F;
-        float dTheta = Mth.PI / 16; // i chose this because mc pixels are 1/16 of a block, if ur computer lags womp womp
-        float dRad = rad / 16;
-        for (float i = 0; i < Mth.TWO_PI; i += dTheta) {
-            for (float r = dRad; r <= rad; r += dRad) {
-                pnt1 = pos.add(r * Mth.cos(i), 0, r * Mth.sin(i));
-                pnt1 = castShadowVertex(pnt1);
+                    if (pnt1 == null || pnt2 == null || pnt3 == null || pnt4 == null)
+                        continue;
 
-                pnt2 = pos.add((r + dRad) * Mth.cos(i), 0, (r + dRad) * Mth.sin(i));
-                pnt2 = castShadowVertex(pnt2);
-
-                pnt3 = pos.add((r + dRad) * Mth.cos(i + dTheta), 0, (r + dRad) * Mth.sin(i + dTheta));
-                pnt3 = castShadowVertex(pnt3);
-
-                pnt4 = pos.add(r * Mth.cos(i + dTheta), 0, r * Mth.sin(i + dTheta));
-                pnt4 = castShadowVertex(pnt4);
-
-                if (pnt1 == null || pnt2 == null || pnt3 == null || pnt4 == null)
-                    continue;
-
-                pnt1 = e.getOffsetPos(pnt1);
-                pnt2 = e.getOffsetPos(pnt2);
-                pnt3 = e.getOffsetPos(pnt3);
-                pnt4 = e.getOffsetPos(pnt4);
-                buf.addVertex(mat, (float) pnt1.x, (float) pnt1.y, (float) pnt1.z).setColor(color.getHexCustomAlpha(r / rad));
-                buf.addVertex(mat, (float) pnt2.x, (float) pnt2.y, (float) pnt2.z).setColor(color.getHexCustomAlpha((r + dRad) / rad));
-                buf.addVertex(mat, (float) pnt3.x, (float) pnt3.y, (float) pnt3.z).setColor(color.getHexCustomAlpha((r + dRad) / rad));
-                buf.addVertex(mat, (float) pnt4.x, (float) pnt4.y, (float) pnt4.z).setColor(color.getHexCustomAlpha(r / rad));
+                    pnt1 = pnt1.subtract(cameraPosition);
+                    pnt2 = pnt2.subtract(cameraPosition);
+                    pnt3 = pnt3.subtract(cameraPosition);
+                    pnt4 = pnt4.subtract(cameraPosition);
+                    buf.addVertex(mat, (float) pnt1.x, (float) pnt1.y, (float) pnt1.z).setColor(color.getHexCustomAlpha(r / rad));
+                    buf.addVertex(mat, (float) pnt2.x, (float) pnt2.y, (float) pnt2.z).setColor(color.getHexCustomAlpha((r + dRad) / rad));
+                    buf.addVertex(mat, (float) pnt3.x, (float) pnt3.y, (float) pnt3.z).setColor(color.getHexCustomAlpha((r + dRad) / rad));
+                    buf.addVertex(mat, (float) pnt4.x, (float) pnt4.y, (float) pnt4.z).setColor(color.getHexCustomAlpha(r / rad));
+                }
             }
-        }
-        RenderUtils.drawBuffer(buf, RenderLayers.QUADS);
+        });
     }
 
     private Vec3 castShadowVertex(Vec3 pnt) {

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/ItemHighlight.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/ItemHighlight.java
@@ -42,16 +42,17 @@ public class ItemHighlight extends ListenerModule {
     );
 
     @EventHandler
-    public void onRenderWorld(RenderWorldEvent e) {
+    public void onRenderWorld(RenderWorldEvent event) {
         if (!renderType.getVal().renderWorld() || !isEnabled())
             return;
 
-        PoseStack matrices = e.getMatrices();
-        float tickDelta = e.getTickCounter().getGameTimeDeltaPartialTick(true);
+        PoseStack matrices = event.getPoseStack();
+        var submitNodeCollector = event.getSubmitNodeCollector();
+        float tickDelta = event.getDeltaTracker().getGameTimeDeltaPartialTick(true);
 
         for (ItemEntity itemEntity : getItemEntities()) {
             ItemStack item = itemEntity.getItem();
-            Vec3 pos = e.getOffsetPos(MathUtils.lerpEntityPosVec(itemEntity, tickDelta));
+            Vec3 pos = event.getCameraRelativePosition(MathUtils.lerpEntityPosVec(itemEntity, tickDelta));
             Rarity rarity = item.getRarity();
 
             if (rarity.ordinal() < rarityFilter.getVal().ordinal())
@@ -59,7 +60,7 @@ public class ItemHighlight extends ListenerModule {
 
             int color = getRarityColor(rarity);
             int fadeColor = 0x00FFFFFF & color;
-            RenderUtils3d.fillCylGradient(matrices, pos.x, pos.y, pos.z, 0.2, 0.25, color, fadeColor);
+            RenderUtils3d.fillCylGradient(matrices, submitNodeCollector, pos.x, pos.y, pos.z, 0.2, 0.25, color, fadeColor);
         }
     }
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/TotemChams.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/TotemChams.java
@@ -124,15 +124,16 @@ public class TotemChams extends ListenerModule {
     }
 
     @EventHandler
-    private void onRenderWorld(RenderWorldEvent e) {
+    private void onRenderWorld(RenderWorldEvent event) {
         if (PlayerUtils.invalid())
             return;
 
-        PoseStack matrices = e.getMatrices();
-        float tickDelta = e.getTickCounter().getGameTimeDeltaPartialTick(true);
+        PoseStack matrices = event.getPoseStack();
+        var submitNodeCollector = event.getSubmitNodeCollector();
+        float tickDelta = event.getDeltaTracker().getGameTimeDeltaPartialTick(true);
 
         for (ChamRagDoll<?> doll : ragDolls)
-            doll.render(matrices, getColor(), tickDelta);
+            doll.render(matrices, submitNodeCollector, getColor(), tickDelta);
     }
 
     public int getColor() {

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/Trajectories.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/Trajectories.java
@@ -129,10 +129,10 @@ public class Trajectories extends ListenerModule {
     }
 
     @EventHandler
-    public void onRenderWorld(RenderWorldEvent e) {
-        tickDelta = e.getTickCounter().getGameTimeDeltaPartialTick(true);
+    public void onRenderWorld(RenderWorldEvent event) {
+        tickDelta = event.getDeltaTracker().getGameTimeDeltaPartialTick(true);
         if (currentResult != null)
-            currentResult.draw(e, tickDelta);
+            currentResult.draw(event.getPoseStack(), event.getSubmitNodeCollector(), event.getCamera().position(), tickDelta);
     }
 
     public float getTickDelta() {

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/ChamRagDoll.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/ChamRagDoll.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams;
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.Global;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.ChamPart;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
@@ -39,9 +40,9 @@ public abstract class ChamRagDoll<P extends ChamPart> implements Global {
 
     public abstract void tick(float gravity, float maxVelocity);
 
-    protected abstract void renderPart(P part, PoseStack matrices, int color, float tickDelta);
+    protected abstract void renderPart(P part, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta);
 
-    public void render(PoseStack matrices, int color, float tickDelta) {
+    public void render(PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta) {
         Vector3f c = new Vec3(x, y, z).subtract(mc.gameRenderer.mainCamera().position()).toVector3f();
         Quaternionf pitch = new Quaternionf().rotationX((float) Math.toRadians(glidingProgress == 1 ? this.pitch + 90 : glidingProgress * 90));
         Quaternionf yaw = new Quaternionf().rotationY((float) Math.toRadians(-this.yaw));
@@ -55,7 +56,7 @@ public abstract class ChamRagDoll<P extends ChamPart> implements Global {
         color = (alpha << 24) | (color & 0x00FFFFFF);
 
         for (P part : parts.values())
-            renderPart(part, matrices, color, tickDelta);
+            renderPart(part, matrices, submitNodeCollector, color, tickDelta);
 
         matrices.popPose();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/ExplodingChamRagDoll.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/ExplodingChamRagDoll.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.ChamPart;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.ExplodingChamPart;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.world.entity.player.Player;
 
 public class ExplodingChamRagDoll extends ChamRagDoll<ExplodingChamPart> {
@@ -45,8 +46,8 @@ public class ExplodingChamRagDoll extends ChamRagDoll<ExplodingChamPart> {
     }
 
     @Override
-    protected void renderPart(ExplodingChamPart part, PoseStack matrices, int color, float tickDelta) {
-        part.render(matrices, color, tickDelta, age);
+    protected void renderPart(ExplodingChamPart part, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta) {
+        part.render(matrices, submitNodeCollector, color, tickDelta, age);
     }
 
     private int randomSign() {

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/FadingChamRagDoll.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/FadingChamRagDoll.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams;
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.ChamPart;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.FadingChamPart;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.world.entity.player.Player;
 
 public class FadingChamRagDoll extends ChamRagDoll<FadingChamPart> {
@@ -33,7 +34,7 @@ public class FadingChamRagDoll extends ChamRagDoll<FadingChamPart> {
     }
 
     @Override
-    protected void renderPart(FadingChamPart part, PoseStack matrices, int color, float tickDelta) {
-        part.render(matrices, color, tickDelta, age);
+    protected void renderPart(FadingChamPart part, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta) {
+        part.render(matrices, submitNodeCollector, color, tickDelta, age);
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/RisingChamRagDoll.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/RisingChamRagDoll.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams;
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.ChamPart;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.RisingChamPart;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.world.entity.player.Player;
 
 public class RisingChamRagDoll extends ChamRagDoll<RisingChamPart> {
@@ -33,7 +34,7 @@ public class RisingChamRagDoll extends ChamRagDoll<RisingChamPart> {
     }
 
     @Override
-    protected void renderPart(RisingChamPart part, PoseStack matrices, int color, float tickDelta) {
-        part.render(matrices, color, tickDelta, age);
+    protected void renderPart(RisingChamPart part, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta) {
+        part.render(matrices, submitNodeCollector, color, tickDelta, age);
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/VortexChamRagDoll.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/VortexChamRagDoll.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams;
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.ChamPart;
 import io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts.VortexChamPart;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.world.entity.player.Player;
 
 public class VortexChamRagDoll extends ChamRagDoll<VortexChamPart> {
@@ -34,7 +35,7 @@ public class VortexChamRagDoll extends ChamRagDoll<VortexChamPart> {
     }
 
     @Override
-    protected void renderPart(VortexChamPart part, PoseStack matrices, int color, float tickDelta) {
-        part.render(matrices, color, tickDelta, age);
+    protected void renderPart(VortexChamPart part, PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta) {
+        part.render(matrices, submitNodeCollector, color, tickDelta, age);
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/ChamPart.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/ChamPart.java
@@ -1,6 +1,7 @@
 package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.parts;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 
 public abstract class ChamPart {
 
@@ -26,5 +27,5 @@ public abstract class ChamPart {
 
     public abstract void tick(float gravity, float ageDelta);
 
-    public abstract void render(PoseStack matrices, int color, float tickDelta, int age);
+    public abstract void render(PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta, int age);
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/ExplodingChamPart.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/ExplodingChamPart.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils3d;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import org.joml.Quaternionf;
 
 public class ExplodingChamPart extends ChamPart {
@@ -54,7 +55,7 @@ public class ExplodingChamPart extends ChamPart {
     }
 
     @Override
-    public void render(PoseStack matrices, int color, float tickDelta, int age) {
+    public void render(PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta, int age) {
         float x = (float) MathUtils.lerp(prevX, this.x, tickDelta);
         float y = (float) MathUtils.lerp(prevY, this.y, tickDelta);
         float z = (float) MathUtils.lerp(prevZ, this.z, tickDelta);
@@ -67,11 +68,11 @@ public class ExplodingChamPart extends ChamPart {
         matrices.rotateAround(getRotation(tickDelta), cx, cy, cz);
         matrices.translate(x, y, z);
 
-        RenderUtils3d.fillRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, color, true);
+        RenderUtils3d.fillRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, color, true);
 
         int alpha = Math.min((color >> 24 & 0xFF) * 5, 0xFF);
         color = (alpha << 24) | (color & 0x00FFFFFF);
-        RenderUtils3d.drawRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, color, true);
+        RenderUtils3d.drawRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, color, true);
 
         matrices.popPose();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/FadingChamPart.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/FadingChamPart.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils3d;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import org.joml.Quaternionf;
 
 public class FadingChamPart extends ChamPart {
@@ -107,7 +108,7 @@ public class FadingChamPart extends ChamPart {
     }
 
     @Override
-    public void render(PoseStack matrices, int color, float tickDelta, int age) {
+    public void render(PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta, int age) {
         float globalProgress = age / 100.0f;
         if (!isVisible(globalProgress)) return;
 
@@ -126,11 +127,11 @@ public class FadingChamPart extends ChamPart {
         float fadeAlpha = getFadeAlpha(globalProgress);
         int fadeColor = ((int) (((color >> 24) & 0xFF) * fadeAlpha) << 24) | (color & 0x00FFFFFF);
 
-        RenderUtils3d.fillRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, fadeColor, true);
+        RenderUtils3d.fillRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, fadeColor, true);
 
         int outlineAlpha = Math.min((int) (((color >> 24) & 0xFF) * fadeAlpha * 1.3f), 0xFF);
         int outlineColor = (outlineAlpha << 24) | (color & 0x00FFFFFF);
-        RenderUtils3d.drawRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, outlineColor, true);
+        RenderUtils3d.drawRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, outlineColor, true);
 
         matrices.popPose();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/RisingChamPart.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/RisingChamPart.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils3d;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import org.joml.Quaternionf;
 
 // Soul-like rise: the part drifts upward while gently swaying and slowly spinning.
@@ -48,7 +49,7 @@ public class RisingChamPart extends ChamPart {
     }
 
     @Override
-    public void render(PoseStack matrices, int color, float tickDelta, int age) {
+    public void render(PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta, int age) {
         float x = (float) MathUtils.lerp(prevX, this.x, tickDelta);
         float y = (float) MathUtils.lerp(prevY, this.y, tickDelta);
         float z = (float) MathUtils.lerp(prevZ, this.z, tickDelta);
@@ -61,11 +62,11 @@ public class RisingChamPart extends ChamPart {
         matrices.rotateAround(getRotation(tickDelta), cx, cy, cz);
         matrices.translate(x, y, z);
 
-        RenderUtils3d.fillRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, color, true);
+        RenderUtils3d.fillRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, color, true);
 
         int alpha = Math.min((color >> 24 & 0xFF) * 5, 0xFF);
         int outline = (alpha << 24) | (color & 0x00FFFFFF);
-        RenderUtils3d.drawRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, outline, true);
+        RenderUtils3d.drawRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, outline, true);
 
         matrices.popPose();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/VortexChamPart.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/totemchams/parts/VortexChamPart.java
@@ -3,6 +3,7 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.totemchams.
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils3d;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import org.joml.Quaternionf;
 
 // Vortex: the part spirals outward and upward around the doll's axis while spinning.
@@ -47,7 +48,7 @@ public class VortexChamPart extends ChamPart {
     }
 
     @Override
-    public void render(PoseStack matrices, int color, float tickDelta, int age) {
+    public void render(PoseStack matrices, SubmitNodeCollector submitNodeCollector, int color, float tickDelta, int age) {
         float x = (float) MathUtils.lerp(prevX, this.x, tickDelta);
         float y = (float) MathUtils.lerp(prevY, this.y, tickDelta);
         float z = (float) MathUtils.lerp(prevZ, this.z, tickDelta);
@@ -60,11 +61,11 @@ public class VortexChamPart extends ChamPart {
         matrices.rotateAround(getRotation(tickDelta), cx, cy, cz);
         matrices.translate(x, y, z);
 
-        RenderUtils3d.fillRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, color, true);
+        RenderUtils3d.fillRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, color, true);
 
         int alpha = Math.min((color >> 24 & 0xFF) * 5, 0xFF);
         int outline = (alpha << 24) | (color & 0x00FFFFFF);
-        RenderUtils3d.drawRectPrism(matrices, minX, minY, minZ, maxX, maxY, maxZ, outline, true);
+        RenderUtils3d.drawRectPrism(matrices, submitNodeCollector, minX, minY, minZ, maxX, maxY, maxZ, outline, true);
 
         matrices.popPose();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/trajectories/ProjectilePath.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/rendering/trajectories/ProjectilePath.java
@@ -2,7 +2,6 @@ package io.github.itzispyder.clickcrystals.modules.modules.rendering.trajectorie
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import io.github.itzispyder.clickcrystals.Global;
-import io.github.itzispyder.clickcrystals.events.events.world.RenderWorldEvent;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
 import io.github.itzispyder.clickcrystals.util.minecraft.MissHitResult;
 import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
@@ -10,6 +9,7 @@ import io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils3d;
 import net.minecraft.client.Camera;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -108,12 +108,11 @@ public class ProjectilePath implements Global {
     public record Result(HitResult hit, List<Vec3> vertices) {
         public static final Result MISS = new Result(MissHitResult.MISS, new ArrayList<>());
 
-        public void draw(RenderWorldEvent e, float tickDelta) {
+        public void draw(PoseStack matrices, SubmitNodeCollector submitNodeCollector, Vec3 cameraPosition, float tickDelta) {
             if (vertices.size() <= 1)
                 return;
 
             LocalPlayer p = PlayerUtils.player();
-            PoseStack matrices = e.getMatrices();
             Vec3 playerPos = MathUtils.lerpEntityPosVec(p, tickDelta);
             Vec3 playerEye = MathUtils.lerpEntityEyeVec(p, tickDelta);
             Vec3 offset = playerPos.subtract(p.xOld, p.yOld, p.zOld);
@@ -131,28 +130,28 @@ public class ProjectilePath implements Global {
                 for (int i = 0; i < vertices.size() - 1; i++) {
                     boolean player = (int)vertices.get(i).y == (int)p.getY();
                     boolean hitEnt = hit.getType() == HitResult.Type.ENTITY;
-                    Vec3 v1 = e.getOffsetPos(vertices.get(i).add(offset));
-                    Vec3 v2 = e.getOffsetPos(vertices.get(i + 1).add(offset));
-                    RenderUtils3d.drawFlatLine(matrices, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z, 0.05, player || hitEnt ? 0xFFFF4040 : 0xFFFFFFFF);
+                    Vec3 v1 = vertices.get(i).add(offset).subtract(cameraPosition);
+                    Vec3 v2 = vertices.get(i + 1).add(offset).subtract(cameraPosition);
+                    RenderUtils3d.drawFlatLine(matrices, submitNodeCollector, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z, 0.05, player || hitEnt ? 0xFFFF4040 : 0xFFFFFFFF);
                 }
             }
 
             if (hit.getType() == HitResult.Type.MISS)
                 return;
             else if (hit instanceof BlockHitResult block)
-                RenderUtils3d.renderBlock(matrices, e.getOffsetPos(block.getBlockPos()), 0x40FFFFFF);
+                RenderUtils3d.renderBlock(matrices, submitNodeCollector, Vec3.atLowerCornerOf(block.getBlockPos()).subtract(cameraPosition), 0x40FFFFFF);
             else if (hit instanceof EntityHitResult eHit && eHit.getEntity() instanceof LivingEntity liv && liv != p) {
-                AABB box = liv.getBoundingBox().move(e.getCamera().position().reverse());
-                RenderUtils3d.fillBox(matrices, box, 0x40FF4040);
+                AABB box = liv.getBoundingBox().move(cameraPosition.reverse());
+                RenderUtils3d.fillBox(matrices, submitNodeCollector, box, 0x40FF4040);
             }
 
             if (last.distanceTo(p.getEyePosition()) > 3.0) {
-//                Vec3d from = e.getOffsetPos(playerPos);
-                Vec3 to = e.getOffsetPos(last.add(offset));
+//                Vec3 from = playerPos.subtract(cameraPosition);
+                Vec3 to = last.add(offset).subtract(cameraPosition);
                 double w = 0.125;
                 AABB box = new AABB(to.add(-w, -w, -w), to.add(w, w, w));
-                RenderUtils3d.fillBox(matrices, box, 0x80FF4040);
-//                RenderUtils3d.drawLine(matrices, to.x, to.y, to.z, from.x, from.y, from.z, 0xFFFF4040);
+                RenderUtils3d.fillBox(matrices, submitNodeCollector, box, 0x80FF4040);
+//                RenderUtils3d.drawLine(matrices, submitNodeCollector, to.x, to.y, to.z, from.x, from.y, from.z, 0xFFFF4040);
             }
         }
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/render/RenderUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/render/RenderUtils.java
@@ -1,15 +1,10 @@
 package io.github.itzispyder.clickcrystals.util.minecraft.render;
 
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.Tesselator;
-import com.mojang.blaze3d.vertex.VertexFormat;
 import io.github.itzispyder.clickcrystals.Global;
 import io.github.itzispyder.clickcrystals.gui.misc.Color;
 import io.github.itzispyder.clickcrystals.util.minecraft.render.states.*;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.renderer.RenderPipelines;
-import net.minecraft.client.renderer.feature.CustomFeatureRenderer;
-import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.item.ItemStack;
@@ -239,16 +234,6 @@ public final class RenderUtils implements Global {
 
     public static void drawItem(GuiGraphicsExtractor context, ItemStack item, int x, int y) {
         drawItem(context, item, x, y, 1.0F);
-    }
-
-    // util
-    public static void drawBuffer(BufferBuilder buf, RenderType layer) {
-        layer.draw(buf.buildOrThrow());
-    }
-
-    public static BufferBuilder getBuffer(VertexFormat.Mode drawMode, VertexFormat format) {
-        CustomFeatureRenderer renderer = new CustomFeatureRenderer();
-        return Tesselator.getInstance().begin(drawMode, format);
     }
 
     public static int width() {

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/render/RenderUtils3d.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/render/RenderUtils3d.java
@@ -1,33 +1,26 @@
 package io.github.itzispyder.clickcrystals.util.minecraft.render;
 
-import com.mojang.blaze3d.vertex.BufferBuilder;
-import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.math.Axis;
 import io.github.itzispyder.clickcrystals.gui.misc.Color;
 import io.github.itzispyder.clickcrystals.util.MathUtils;
+import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.util.Mth;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 
-import static io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils.drawBuffer;
-import static io.github.itzispyder.clickcrystals.util.minecraft.render.RenderUtils.getBuffer;
-
 public class RenderUtils3d {
 
-    public static void drawLine(PoseStack matrices, double x1, double y1, double z1, double x2, double y2, double z2, int color) {
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.DEBUG_LINES, DefaultVertexFormat.POSITION_COLOR);
-        Matrix4f mat = matrices.last().pose();
-
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z2).setColor(color);
-
-        drawBuffer(buf, RenderLayers.LINES);
+    public static void drawLine(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x1, double y1, double z1, double x2, double y2, double z2, int color) {
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.LINES, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            buf.addVertex(mat, (float)x1, (float)y1, (float)z1).setColor(color);
+            buf.addVertex(mat, (float)x2, (float)y2, (float)z2).setColor(color);
+        });
     }
 
-    public static void drawFlatLine(PoseStack matrices, double x1, double y1, double z1, double x2, double y2, double z2, double width, int color) {
+    public static void drawFlatLine(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x1, double y1, double z1, double x2, double y2, double z2, double width, int color) {
         int colorQuat = (0x40 << 24) | (0x00FFFFFF & color);
         int colorHalf = (0x80 << 24) | (0x00FFFFFF & color);
         int colorFull = (0xFF << 24) | (0x00FFFFFF & color);
@@ -42,225 +35,205 @@ public class RenderUtils3d {
         Vec3 v3 = MathUtils.forward(to, MathUtils.rotate(dir, to, 0, 90F), half);
         Vec3 v4 = MathUtils.forward(from, MathUtils.rotate(dir, from, 0, 90F), half);
 
-        // rect
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-        Matrix4f mat = matrices.last().pose();
-
-        buf.addVertex(mat, (float)v1.x, (float)v1.y, (float)v1.z).setColor(colorQuat);
-        buf.addVertex(mat, (float)v2.x, (float)v2.y, (float)v2.z).setColor(colorQuat);
-        buf.addVertex(mat, (float)v3.x, (float)v3.y, (float)v3.z).setColor(colorQuat);
-        buf.addVertex(mat, (float)v4.x, (float)v4.y, (float)v4.z).setColor(colorQuat);
-
-        drawBuffer(buf, RenderLayers.QUADS);
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.QUADS, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            buf.addVertex(mat, (float)v1.x, (float)v1.y, (float)v1.z).setColor(colorQuat);
+            buf.addVertex(mat, (float)v2.x, (float)v2.y, (float)v2.z).setColor(colorQuat);
+            buf.addVertex(mat, (float)v3.x, (float)v3.y, (float)v3.z).setColor(colorQuat);
+            buf.addVertex(mat, (float)v4.x, (float)v4.y, (float)v4.z).setColor(colorQuat);
+        });
 
         // lines
-        drawLine(matrices, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z, colorFull);
-        drawLine(matrices, v3.x, v3.y, v3.z, v4.x, v4.y, v4.z, colorFull);
+        drawLine(matrices, submitNodeCollector, v1.x, v1.y, v1.z, v2.x, v2.y, v2.z, colorFull);
+        drawLine(matrices, submitNodeCollector, v3.x, v3.y, v3.z, v4.x, v4.y, v4.z, colorFull);
 //        drawLine(matrices, v1.x, v1.y, v1.z, v4.x, v4.y, v4.z, colorHalf);
 //        drawLine(matrices, v3.x, v3.y, v3.z, v2.x, v2.y, v2.z, colorHalf);
     }
 
-    public static void fillCube(PoseStack matrices, double x, double y, double z, int color) {
-        Matrix4f mat = matrices.last().pose();
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
-
+    public static void fillCube(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x, double y, double z, int color) {
         float diff = 0.0001F; // fix z-fighting
 
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0) - diff, (float)(z + 0)).setColor(color); // bottom
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0) - diff, (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0) - diff, (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0) - diff, (float)(z + 1)).setColor(color);
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.QUADS, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0) - diff, (float)(z + 0)).setColor(color); // bottom
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0) - diff, (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0) - diff, (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0) - diff, (float)(z + 1)).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1) + diff, (float)(z + 0)).setColor(color); // top
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1) + diff, (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1) + diff, (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1) + diff, (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1) + diff, (float)(z + 0)).setColor(color); // top
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1) + diff, (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1) + diff, (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1) + diff, (float)(z + 1)).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0) - diff).setColor(color); // front
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0) - diff).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0) - diff).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0) - diff).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0) - diff).setColor(color); // front
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0) - diff).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0) - diff).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0) - diff).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1) + diff).setColor(color); // back
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1) + diff).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1) + diff).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1) + diff).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1) + diff).setColor(color); // back
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1) + diff).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1) + diff).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1) + diff).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 0), (float)(z + 0)).setColor(color); // left
-        buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 1), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 0), (float)(z + 0)).setColor(color); // left
+            buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 1), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0) - diff, (float)(y + 0), (float)(z + 1)).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 0), (float)(z + 0)).setColor(color); // right
-        buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 1), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 0), (float)(z + 1)).setColor(color);
-
-        drawBuffer(buf, RenderLayers.QUADS);
+            buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 0), (float)(z + 0)).setColor(color); // right
+            buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 1), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1) + diff, (float)(y + 0), (float)(z + 1)).setColor(color);
+        });
     }
 
-    public static void fillBox(PoseStack matrices, AABB box, int color) {
-        fillRectPrism(matrices, (float)box.minX, (float)box.minY, (float)box.minZ, (float)box.maxX, (float)box.maxY, (float)box.maxZ, color);
+    public static void fillBox(PoseStack matrices, SubmitNodeCollector submitNodeCollector, AABB box, int color) {
+        fillRectPrism(matrices, submitNodeCollector, (float)box.minX, (float)box.minY, (float)box.minZ, (float)box.maxX, (float)box.maxY, (float)box.maxZ, color);
     }
 
-    public static void fillRectPrism(PoseStack matrices, float x1, float y1, float z1, float x2, float y2, float z2, int color, boolean cull) {
-        Matrix4f mat = matrices.last().pose();
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+    public static void fillRectPrism(PoseStack matrices, SubmitNodeCollector submitNodeCollector, float x1, float y1, float z1, float x2, float y2, float z2, int color, boolean cull) {
+        submitNodeCollector.submitCustomGeometry(matrices, cull ? RenderLayers.QUADS_CULL : RenderLayers.QUADS, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            buf.addVertex(mat, x1, y1, z1).setColor(color); // bottom
+            buf.addVertex(mat, x2, y1, z1).setColor(color);
+            buf.addVertex(mat, x2, y1, z2).setColor(color);
+            buf.addVertex(mat, x1, y1, z2).setColor(color);
 
-        buf.addVertex(mat, x1, y1, z1).setColor(color); // bottom
-        buf.addVertex(mat, x2, y1, z1).setColor(color);
-        buf.addVertex(mat, x2, y1, z2).setColor(color);
-        buf.addVertex(mat, x1, y1, z2).setColor(color);
+            buf.addVertex(mat, x1, y2, z1).setColor(color); // top
+            buf.addVertex(mat, x2, y2, z1).setColor(color);
+            buf.addVertex(mat, x2, y2, z2).setColor(color);
+            buf.addVertex(mat, x1, y2, z2).setColor(color);
 
-        buf.addVertex(mat, x1, y2, z1).setColor(color); // top
-        buf.addVertex(mat, x2, y2, z1).setColor(color);
-        buf.addVertex(mat, x2, y2, z2).setColor(color);
-        buf.addVertex(mat, x1, y2, z2).setColor(color);
+            buf.addVertex(mat, x1, y1, z1).setColor(color); // front
+            buf.addVertex(mat, x2, y1, z1).setColor(color);
+            buf.addVertex(mat, x2, y2, z1).setColor(color);
+            buf.addVertex(mat, x1, y2, z1).setColor(color);
 
-        buf.addVertex(mat, x1, y1, z1).setColor(color); // front
-        buf.addVertex(mat, x2, y1, z1).setColor(color);
-        buf.addVertex(mat, x2, y2, z1).setColor(color);
-        buf.addVertex(mat, x1, y2, z1).setColor(color);
+            buf.addVertex(mat, x1, y1, z2).setColor(color); // back
+            buf.addVertex(mat, x2, y1, z2).setColor(color);
+            buf.addVertex(mat, x2, y2, z2).setColor(color);
+            buf.addVertex(mat, x1, y2, z2).setColor(color);
 
-        buf.addVertex(mat, x1, y1, z2).setColor(color); // back
-        buf.addVertex(mat, x2, y1, z2).setColor(color);
-        buf.addVertex(mat, x2, y2, z2).setColor(color);
-        buf.addVertex(mat, x1, y2, z2).setColor(color);
+            buf.addVertex(mat, x1, y1, z1).setColor(color); // left
+            buf.addVertex(mat, x1, y2, z1).setColor(color);
+            buf.addVertex(mat, x1, y2, z2).setColor(color);
+            buf.addVertex(mat, x1, y1, z2).setColor(color);
 
-        buf.addVertex(mat, x1, y1, z1).setColor(color); // left
-        buf.addVertex(mat, x1, y2, z1).setColor(color);
-        buf.addVertex(mat, x1, y2, z2).setColor(color);
-        buf.addVertex(mat, x1, y1, z2).setColor(color);
-
-        buf.addVertex(mat, x2, y1, z1).setColor(color); // right
-        buf.addVertex(mat, x2, y2, z1).setColor(color);
-        buf.addVertex(mat, x2, y2, z2).setColor(color);
-        buf.addVertex(mat, x2, y1, z2).setColor(color);
-
-        drawBuffer(buf, cull ? RenderLayers.QUADS_CULL : RenderLayers.QUADS);
+            buf.addVertex(mat, x2, y1, z1).setColor(color); // right
+            buf.addVertex(mat, x2, y2, z1).setColor(color);
+            buf.addVertex(mat, x2, y2, z2).setColor(color);
+            buf.addVertex(mat, x2, y1, z2).setColor(color);
+        });
     }
 
-    public static void fillRectPrism(PoseStack matrices, float x1, float y1, float z1, float x2, float y2, float z2, int color) {
-        fillRectPrism(matrices, x1, y1, z1, x2, y2, z2, color, false);
+    public static void fillRectPrism(PoseStack matrices, SubmitNodeCollector submitNodeCollector, float x1, float y1, float z1, float x2, float y2, float z2, int color) {
+        fillRectPrism(matrices, submitNodeCollector, x1, y1, z1, x2, y2, z2, color, false);
     }
 
-    public static void fillCyl(PoseStack matrices, double x, double y, double z, double radius, double height, int color) {
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_COLOR);
-        Matrix4f mat = matrices.last().pose();
-
-        for (int i = 0; i <= 360; i += 24) {
-            float angle = (float)Math.toRadians(i);
-            float cx = (float)(x + Mth.cos(angle) * radius);
-            float cz = (float)(z + Mth.sin(angle) * radius);
-            buf.addVertex(mat, cx, (float)y, cz).setColor(color);
-            buf.addVertex(mat, cx, (float)(y + height), cz).setColor(color);
-        }
-
-        drawBuffer(buf, RenderLayers.TRI_STRIP);
+    public static void fillCyl(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x, double y, double z, double radius, double height, int color) {
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.TRI_STRIP, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            for (int i = 0; i <= 360; i += 24) {
+                float angle = (float)Math.toRadians(i);
+                float cx = (float)(x + Mth.cos(angle) * radius);
+                float cz = (float)(z + Mth.sin(angle) * radius);
+                buf.addVertex(mat, cx, (float)y, cz).setColor(color);
+                buf.addVertex(mat, cx, (float)(y + height), cz).setColor(color);
+            }
+        });
     }
 
-    public static void fillCylGradient(PoseStack matrices, double x, double y, double z, double radius, double height, int colorBottom, int colorTop) {
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.TRIANGLE_STRIP, DefaultVertexFormat.POSITION_COLOR);
-        Matrix4f mat = matrices.last().pose();
-
-        for (int i = 0; i <= 360; i += 30) {
-            float angle = (float)Math.toRadians(i);
-            float cx = (float)(x + Mth.cos(angle) * radius);
-            float cz = (float)(z + Mth.sin(angle) * radius);
-            buf.addVertex(mat, cx, (float)y, cz).setColor(colorBottom);
-            buf.addVertex(mat, cx, (float)(y + height), cz).setColor(colorTop);
-        }
-
-        drawBuffer(buf, RenderLayers.TRI_STRIP_CULL);
+    public static void fillCylGradient(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x, double y, double z, double radius, double height, int colorBottom, int colorTop) {
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.TRI_STRIP_CULL, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            for (int i = 0; i <= 360; i += 30) {
+                float angle = (float)Math.toRadians(i);
+                float cx = (float)(x + Mth.cos(angle) * radius);
+                float cz = (float)(z + Mth.sin(angle) * radius);
+                buf.addVertex(mat, cx, (float)y, cz).setColor(colorBottom);
+                buf.addVertex(mat, cx, (float)(y + height), cz).setColor(colorTop);
+            }
+        });
     }
 
-    public static void drawCube(PoseStack matrices, double x, double y, double z, int color) {
-        Matrix4f mat = matrices.last().pose();
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.DEBUG_LINES, DefaultVertexFormat.POSITION_COLOR);
+    public static void drawCube(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x, double y, double z, int color) {
+        submitNodeCollector.submitCustomGeometry(matrices, RenderLayers.LINES, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0)).setColor(color); // bottom
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0)).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0)).setColor(color); // bottom
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0)).setColor(color); // top
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0)).setColor(color);
 
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0)).setColor(color); // top
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0)).setColor(color);
-
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0)).setColor(color); // pillars
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1)).setColor(color);
-        buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1)).setColor(color);
-
-        drawBuffer(buf, RenderLayers.LINES);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 0)).setColor(color); // pillars
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 0)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 1), (float)(y + 1), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 0), (float)(z + 1)).setColor(color);
+            buf.addVertex(mat, (float)(x + 0), (float)(y + 1), (float)(z + 1)).setColor(color);
+        });
     }
 
-    public static void renderBlock(PoseStack matrices, Vec3 block, int color) {
+    public static void renderBlock(PoseStack matrices, SubmitNodeCollector submitNodeCollector, Vec3 block, int color) {
         var c = new Color(color);
-        fillCube(matrices, block.x(), block.y(), block.z(), c.getHex());
-        drawCube(matrices, block.x(), block.y(), block.z(), c.getHexOpaque());
+        fillCube(matrices, submitNodeCollector, block.x(), block.y(), block.z(), c.getHex());
+        drawCube(matrices, submitNodeCollector, block.x(), block.y(), block.z(), c.getHexOpaque());
     }
 
-    public static void drawRectPrism(PoseStack matrices, double x1, double y1, double z1, double x2, double y2, double z2, int color, boolean cull) {
-        Matrix4f mat = matrices.last().pose();
-        BufferBuilder buf = getBuffer(VertexFormat.Mode.DEBUG_LINES, DefaultVertexFormat.POSITION_COLOR);
+    public static void drawRectPrism(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x1, double y1, double z1, double x2, double y2, double z2, int color, boolean cull) {
         AABB box = new AABB(x1, y1, z1, x2, y2, z2);
 
-        x1 = box.minX;
-        y1 = box.minY;
-        z1 = box.minZ;
-        x2 = box.maxX;
-        y2 = box.maxY;
-        z2 = box.maxZ;
+        submitNodeCollector.submitCustomGeometry(matrices, cull ? RenderLayers.LINES_CULL : RenderLayers.LINES, (pose, buf) -> {
+            Matrix4f mat = pose.pose();
 
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z1).setColor(color); // bottom
-        buf.addVertex(mat, (float)x2, (float)y1, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y1, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y1, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y1, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z1).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.minY, (float)box.minZ).setColor(color); // bottom
+            buf.addVertex(mat, (float)box.maxX, (float)box.minY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.minY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.minY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.minY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.minY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.minY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.minY, (float)box.minZ).setColor(color);
 
-        buf.addVertex(mat, (float)x1, (float)y2, (float)z1).setColor(color); // top
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y2, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y2, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y2, (float)z1).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.maxY, (float)box.minZ).setColor(color); // top
+            buf.addVertex(mat, (float)box.maxX, (float)box.maxY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.maxY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.maxY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.maxY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.maxY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.maxY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.maxY, (float)box.minZ).setColor(color);
 
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z1).setColor(color); // pillars
-        buf.addVertex(mat, (float)x1, (float)y2, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y1, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z1).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y1, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x2, (float)y2, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y1, (float)z2).setColor(color);
-        buf.addVertex(mat, (float)x1, (float)y2, (float)z2).setColor(color);
-
-        drawBuffer(buf, cull ? RenderLayers.LINES_CULL : RenderLayers.LINES);
+            buf.addVertex(mat, (float)box.minX, (float)box.minY, (float)box.minZ).setColor(color); // pillars
+            buf.addVertex(mat, (float)box.minX, (float)box.maxY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.minY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.maxY, (float)box.minZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.minY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.maxX, (float)box.maxY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.minY, (float)box.maxZ).setColor(color);
+            buf.addVertex(mat, (float)box.minX, (float)box.maxY, (float)box.maxZ).setColor(color);
+        });
     }
 
-    public static void drawRectPrism(PoseStack matrices, double x1, double y1, double z1, double x2, double y2, double z2, int color) {
-        drawRectPrism(matrices, x1, y1, z1, x2, y2, z2, color, false);
+    public static void drawRectPrism(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x1, double y1, double z1, double x2, double y2, double z2, int color) {
+        drawRectPrism(matrices, submitNodeCollector, x1, y1, z1, x2, y2, z2, color, false);
     }
 
-    public static void renderPlayerThingy(PoseStack matrices, double x, double y, double z, float pitch, float yaw, int color) {
+    public static void renderPlayerThingy(PoseStack matrices, SubmitNodeCollector submitNodeCollector, double x, double y, double z, float pitch, float yaw, int color) {
         double pixelsToBlocks = 0.05625; // I used a calculator for this (1.8 / 32) or (player height blocks / player height pixels)
         double b12 = 12 * pixelsToBlocks;
         double b2 = 2 * pixelsToBlocks;
@@ -271,17 +244,17 @@ public class RenderUtils3d {
         matrices.pushPose();
         matrices.rotateAround(Axis.YN.rotationDegrees(yaw), (float)x, (float)y, (float)z);
 
-        drawRectPrism(matrices, x - b4, y + b0, z - b2, x + b0, y + b12, z + b2, color); // left leg
-        drawRectPrism(matrices, x + b4, y + b0, z - b2, x + b0, y + b12, z + b2, color); // right leg
+        drawRectPrism(matrices, submitNodeCollector, x - b4, y + b0, z - b2, x + b0, y + b12, z + b2, color); // left leg
+        drawRectPrism(matrices, submitNodeCollector, x + b4, y + b0, z - b2, x + b0, y + b12, z + b2, color); // right leg
 
-        drawRectPrism(matrices, x - b4, y + b12, z - b2, x + b4, y + b12 + b12, z + b2, color); // body
+        drawRectPrism(matrices, submitNodeCollector, x - b4, y + b12, z - b2, x + b4, y + b12 + b12, z + b2, color); // body
 
-        drawRectPrism(matrices, x - b8, y + b12, z - b2, x - b4, y + b12 + b12, z + b2, color); // left arm
-        drawRectPrism(matrices, x + b8, y + b12, z - b2, x + b4, y + b12 + b12, z + b2, color); // right arm
+        drawRectPrism(matrices, submitNodeCollector, x - b8, y + b12, z - b2, x - b4, y + b12 + b12, z + b2, color); // left arm
+        drawRectPrism(matrices, submitNodeCollector, x + b8, y + b12, z - b2, x + b4, y + b12 + b12, z + b2, color); // right arm
 
         matrices.rotateAround(Axis.XP.rotationDegrees(pitch), (float)x, (float)(y + b12 + b12), (float)z);
 
-        drawRectPrism(matrices, x - b4, y + b12 + b12, z - b4, x + b4, y + b12 + b12 + b8, z + b4, color); // head
+        drawRectPrism(matrices, submitNodeCollector, x - b4, y + b12 + b12, z - b4, x + b4, y + b12 + b12 + b8, z + b4, color); // head
 
         matrices.popPose();
     }

--- a/src/main/resources/clickcrystals.mixins.json
+++ b/src/main/resources/clickcrystals.mixins.json
@@ -17,7 +17,7 @@
     "MixinConnection",
     "MixinEntityRenderer",
     "MixinGameRenderer",
-    "MixinGui",
+    "MixinHud",
     "MixinHumanoidArmorLayer",
     "MixinItemInHandRenderer",
     "MixinKeyboardHandlerHandler",


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Completes the Minecraft 26.2 rendering migration after the rendering submission API changes.

Rendering helpers now receive only the dependencies they use: `PoseStack` and `SubmitNodeCollector`. `RenderWorldEvent` remains at event boundaries and carries only the pose stack, camera, delta tracker, and geometry collector. The port also updates renamed Minecraft and Mixin targets, moves custom world geometry submission into `LevelRenderer.submitFeatures`, and replaces the removed immediate buffer drawing path.

Validation:

- `./gradlew build` passes with Java 25.
- The development client reaches the title screen without Mixin or rendering initialization crashes.
- `RenderWorldEvent` parameters remain only on actual event handlers.
- `git diff --check` passes.

## Related issues

No linked issue.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
- [x] I have joined the [ClickCrystals](https://discord.com/invite/tMaShNzNtP) Discord.