### PR TITLE
Resolve Mod Menu from Modrinth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,9 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    maven { url "https://maven.terraformersmc.com/releases/" }
     maven {
-        name = "Terraformers"
-        url = "https://maven.terraformersmc.com/"
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
     }
     mavenCentral()
     // Add repositories to retrieve artifacts from in here.
@@ -28,7 +27,7 @@ dependencies {
     implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // clickcrystals could still run without ModMenu
-    implementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+    implementation "maven.modrinth:modmenu:${project.modmenu_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Switches the Mod Menu dependency from the Terraformers Maven repository to the Modrinth Maven repository.

The dependency now uses the Modrinth coordinate `maven.modrinth:modmenu:20.0.1`, allowing the unused Terraformers repository declarations to be removed.

Validation:

- Gradle `dependencyInsight` resolves `maven.modrinth:modmenu:20.0.1` from the compile classpath.
- `git diff --check` passes.
- The full build is currently blocked by the pre-existing Minecraft 26.2 rendering errors on `main`; those errors are fixed separately in #146.

## Related issues

Related port work: #146.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined the [ClickCrystals](https://discord.com/invite/tMaShNzNtP) Discord.