### PR TITLE
fixed flashing screens

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/ClickCrystals.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/ClickCrystals.java
@@ -111,9 +111,9 @@ public final class ClickCrystals implements ModInitializer, Global {
             .condition((bind, screen) -> screen == null)
             .onPress(bind -> {
                 if (Module.isEnabled(InGameHuds.class)) {
-                    mc.setScreenAndShow(new HudEditScreen());
+                    mc.gui.setScreen(new HudEditScreen());
                 } else {
-                    ChatUtils.sendClickableMessage("§c§nThe module §c§nInGameHuds §c§nis not enabled! Press this message to enable it.", () -> mc.setScreenAndShow(new ModuleEditScreen(Module.get(InGameHuds.class))));
+                    ChatUtils.sendClickableMessage("§c§nThe module §c§nInGameHuds §c§nis not enabled! Press this message to enable it.", () -> mc.gui.setScreen(new ModuleEditScreen(Module.get(InGameHuds.class))));
                 }
             })
             .onChange(config::saveKeybind)
@@ -124,7 +124,7 @@ public final class ClickCrystals implements ModInitializer, Global {
             .id("command-prefix")
             .defaultKey(GLFW.GLFW_KEY_COMMA)
             .condition((bind, screen) -> screen == null)
-            .onPress(bind -> mc.setScreenAndShow(new ChatScreen("", false)))
+            .onPress(bind -> mc.gui.setScreen(new ChatScreen("", false)))
             .onChange(config::saveKeybind)
             .build();
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/client/commands/commands/KeybindsCommand.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/client/commands/commands/KeybindsCommand.java
@@ -15,7 +15,7 @@ public class KeybindsCommand extends Command {
     public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(context -> {
             system.scheduler.runDelayedTask(() -> {
-                mc.execute(() -> mc.setScreenAndShow(new KeybindScreen()));
+                mc.execute(() -> mc.gui.setScreen(new KeybindScreen()));
             }, 5 * 50);
             return SINGLE_SUCCESS;
         });

--- a/src/main/java/io/github/itzispyder/clickcrystals/client/commands/commands/ProfileCommand.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/client/commands/commands/ProfileCommand.java
@@ -22,7 +22,7 @@ public class ProfileCommand extends Command {
     public void build(LiteralArgumentBuilder<ClientSuggestionProvider> builder) {
         builder.executes(cxt -> {
                     system.scheduler.runDelayedTask(() -> {
-                        mc.execute(() -> mc.setScreenAndShow(new ProfilesScreen()));
+                        mc.execute(() -> mc.gui.setScreen(new ProfilesScreen()));
                     }, 5 * 50);
                     return SINGLE_SUCCESS;
                 })

--- a/src/main/java/io/github/itzispyder/clickcrystals/client/commands/commands/ScriptCommand.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/client/commands/commands/ScriptCommand.java
@@ -27,7 +27,7 @@ public class ScriptCommand extends Command {
         builder.executes(cxt -> {
                     system.scheduler.runDelayedTask(() -> {
                         BrowsingScreen.currentCategory = Categories.SCRIPTED;
-                        mc.execute(() -> mc.setScreenAndShow(new BrowsingScreen()));
+                        mc.execute(() -> mc.gui.setScreen(new BrowsingScreen()));
                     }, 5 * 50);
                     return SINGLE_SUCCESS;
                 })

--- a/src/main/java/io/github/itzispyder/clickcrystals/events/listeners/UserInputListener.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/listeners/UserInputListener.java
@@ -104,7 +104,7 @@ public class UserInputListener implements Listener {
             base.setPlayOpenAnimation(bl);
             base.setPlayCloseAnimation(bl);
         }
-        mc.execute(() -> mc.setScreenAndShow(screen));
+        mc.execute(() -> mc.gui.setScreen(screen));
     }
 
     @EventHandler
@@ -138,7 +138,7 @@ public class UserInputListener implements Listener {
 
     private void handleScreenManagement(SetScreenEvent e) {
         if (e.getScreen() instanceof BrowsingScreen && PlayerUtils.valid() && config.isOverviewMode()) {
-            mc.setScreenAndShow(new OverviewScreen());
+            mc.gui.setScreen(new OverviewScreen());
             return;
         }
         if (e.getScreen() == null && isScreenTracked(e.getPreviousScreen())) {

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/browsingmode/ModuleElement.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/browsingmode/ModuleElement.java
@@ -78,10 +78,10 @@ public class ModuleElement extends GuiElement {
             module.setEnabled(!module.isEnabled(), false);
         }
         else if (button == 1) {
-            mc.setScreenAndShow(new ModuleEditScreen(module));
+            mc.gui.setScreen(new ModuleEditScreen(module));
         }
         else if (button == 2 && module instanceof ScriptedModule m) {
-            mc.setScreenAndShow(new ClickScriptIDE(m));
+            mc.gui.setScreen(new ClickScriptIDE(m));
         }
     }
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/common/interactive/ButtonElement.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/common/interactive/ButtonElement.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 public class ButtonElement extends GuiElement {
 
     public static final Function<Supplier<? extends Screen>, ClickAction> OPEN_SCREEN = supplier -> (mx, my, self) -> {
-        mc.execute(() -> mc.setScreenAndShow(supplier.get()));
+        mc.execute(() -> mc.gui.setScreen(supplier.get()));
     };
 
     private ClickAction clickCallback;

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/common/interactive/SearchResultsElement.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/common/interactive/SearchResultsElement.java
@@ -120,7 +120,7 @@ public class SearchResultsElement extends GuiElement {
         @Override
         public void mouseClicked(double mouseX, double mouseY, int button) {
             if (isHovered((int)mouseX, (int)mouseY)) {
-                mc.setScreenAndShow(new ModuleEditScreen(module));
+                mc.gui.setScreen(new ModuleEditScreen(module));
             }
             super.mouseClicked(mouseX, mouseY, button);
         }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/BanScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/BanScreen.java
@@ -79,6 +79,6 @@ public class BanScreen extends GuiScreen {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new BanScreen());
+        minecraft.gui.setScreen(new BanScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/BulletinScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/BulletinScreen.java
@@ -51,6 +51,6 @@ public class BulletinScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new BulletinScreen());
+        minecraft.gui.setScreen(new BulletinScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/DefaultBase.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/DefaultBase.java
@@ -51,14 +51,14 @@ public abstract class DefaultBase extends AnimatedBase {
 
         buttonSearch = AbstractElement.create().dimensions(navWidth, 12)
                 .tooltip("LEFT-CLICK to search")
-                .onPress(button -> mc.setScreenAndShow(new SearchScreen()))
+                .onPress(button -> mc.gui.setScreen(new SearchScreen()))
                 .onRender((context, mouseX, mouseY, button) -> {
                     RenderUtils.fillRoundHoriLine(context, button.x, button.y, navWidth, 12, Shades.LIGHT);
                     RenderUtils.drawText(context, "§7Search module i.e.", button.x + 7, button.y + button.height / 3, 0.7F, false);
                 }).build();
         buttonHome = AbstractElement.create().dimensions(navWidth, 10)
                 .tooltip("Back to Home")
-                .onPress(button -> mc.setScreenAndShow(new HomeScreen()))
+                .onPress(button -> mc.gui.setScreen(new HomeScreen()))
                 .onRender((context, mouseX, mouseY, button) -> {
                     if (button.isHovered(mouseX, mouseY)) {
                         RenderUtils.fillRoundHoriLine(context, button.x, button.y, navWidth, 10, Shades.LIGHT_GRAY);
@@ -78,7 +78,7 @@ public abstract class DefaultBase extends AnimatedBase {
                 }).build();
         buttonNews = AbstractElement.create().dimensions(navWidth, 10)
                 .tooltip("View announcements")
-                .onPress(button -> mc.setScreenAndShow(new BulletinScreen()))
+                .onPress(button -> mc.gui.setScreen(new BulletinScreen()))
                 .onRender((context, mouseX, mouseY, button) -> {
                     if (button.isHovered(mouseX, mouseY)) {
                         RenderUtils.fillRoundHoriLine(context, button.x, button.y, navWidth, 10, Shades.LIGHT_GRAY);
@@ -88,7 +88,7 @@ public abstract class DefaultBase extends AnimatedBase {
                 }).build();
         buttonSettings = AbstractElement.create().dimensions(navWidth, 10)
                 .tooltip("Browse settings")
-                .onPress(button -> mc.setScreenAndShow(new SettingScreen()))
+                .onPress(button -> mc.gui.setScreen(new SettingScreen()))
                 .onRender((context, mouseX, mouseY, button) -> {
                     if (button.isHovered(mouseX, mouseY)) {
                         RenderUtils.fillRoundHoriLine(context, button.x, button.y, navWidth, 10, Shades.LIGHT_GRAY);

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/DiscordInviteScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/DiscordInviteScreen.java
@@ -43,7 +43,7 @@ public class DiscordInviteScreen extends GuiScreen {
                 }).build();
 
         decline = AbstractElement.create().dimensions(baseWidth / 4, 12)
-                .onPress(button -> mc.setScreenAndShow(new HomeScreen()))
+                .onPress(button -> mc.gui.setScreen(new HomeScreen()))
                 .onRender((context, mouseX, mouseY, button) -> {
                     int fill = button.isHovered(mouseX, mouseY) ? Shades.GRAY : Shades.DARK_GRAY;
                     fillRoundHoriLine(context, button.x, button.y, baseWidth / 4, 12, fill);
@@ -94,6 +94,6 @@ public class DiscordInviteScreen extends GuiScreen {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new DiscordInviteScreen());
+        minecraft.gui.setScreen(new DiscordInviteScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/HomeScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/HomeScreen.java
@@ -114,14 +114,14 @@ public class HomeScreen extends AnimatedBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new HomeScreen());
+        minecraft.gui.setScreen(new HomeScreen());
     }
 
     @Override
     public boolean keyPressed(KeyEvent e) {
         super.keyPressed(e);
         if (e.input() == GLFW.GLFW_KEY_ENTER && this.selected == searchBar && !searchBar.getQuery().isEmpty()) {
-            mc.setScreenAndShow(new SearchScreen() {{
+            mc.gui.setScreen(new SearchScreen() {{
                 this.searchbar.setQuery(HomeScreen.this.searchBar.getQuery());
                 this.filterByQuery(this.searchbar);
             }});
@@ -132,7 +132,7 @@ public class HomeScreen extends AnimatedBase {
     @Override
     public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
         if (!OPENED_BEFORE) {
-            mc.setScreenAndShow(new DiscordInviteScreen());
+            mc.gui.setScreen(new DiscordInviteScreen());
             OPENED_BEFORE = true;
             return true;
         }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/HudEditScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/HudEditScreen.java
@@ -40,7 +40,7 @@ public class HudEditScreen extends GuiScreen {
                     RenderUtils.drawTexture(context,Tex.Icons.SETTINGS, button.x, button.y,button.width, button.height);
                 })
                 .onPress(button -> {
-                    mc.setScreenAndShow(new ModuleEditScreen(Module.get(InGameHuds.class)));
+                    mc.gui.setScreen(new ModuleEditScreen(Module.get(InGameHuds.class)));
                 })
                 .build();
 
@@ -72,7 +72,7 @@ public class HudEditScreen extends GuiScreen {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new HudEditScreen());
+        minecraft.gui.setScreen(new HudEditScreen());
     }
 
     @Override

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/ModuleEditScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/ModuleEditScreen.java
@@ -125,6 +125,6 @@ public class ModuleEditScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new ModuleEditScreen(module));
+        minecraft.gui.setScreen(new ModuleEditScreen(module));
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/SearchScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/SearchScreen.java
@@ -118,6 +118,6 @@ public class SearchScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new SearchScreen());
+        minecraft.gui.setScreen(new SearchScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/modulescreen/BrowsingScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/modulescreen/BrowsingScreen.java
@@ -30,7 +30,7 @@ public class BrowsingScreen extends DefaultBase {
     protected void init() {
         super.init();
         if (!(this instanceof ScriptsBrowsingScreen) && currentCategory == Categories.SCRIPTED)
-            mc.execute(() -> mc.setScreenAndShow(new ScriptsBrowsingScreen()));
+            mc.execute(() -> mc.gui.setScreen(new ScriptsBrowsingScreen()));
     }
 
     @Override
@@ -64,6 +64,6 @@ public class BrowsingScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new BrowsingScreen());
+        minecraft.gui.setScreen(new BrowsingScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/modulescreen/OverviewScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/modulescreen/OverviewScreen.java
@@ -37,7 +37,7 @@ public class OverviewScreen extends GuiScreen {
             .onPress(button -> {
                 ClickCrystals.config.setOverviewMode(false);
                 ClickCrystals.config.save();
-                mc.setScreenAndShow(new BrowsingScreen());
+                mc.gui.setScreen(new BrowsingScreen());
             })
             .build();
 
@@ -132,6 +132,6 @@ public class OverviewScreen extends GuiScreen {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new OverviewScreen());
+        minecraft.gui.setScreen(new OverviewScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/modulescreen/ScriptsBrowsingScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/modulescreen/ScriptsBrowsingScreen.java
@@ -56,7 +56,7 @@ public class ScriptsBrowsingScreen extends BrowsingScreen {
         this.backButton = new ButtonElement("< Back", baseX + baseWidth - 50 - 10, baseY + 10, 50, 15, (mx, my, self) -> {
             File parent = new File(parentFolder).getParentFile();
             parentFolder = parent.getPath();
-            mc.execute(() -> mc.setScreenAndShow(new ScriptsBrowsingScreen()));
+            mc.execute(() -> mc.gui.setScreen(new ScriptsBrowsingScreen()));
             this.removeChild(self);
         });
         updateButtonDisplay();
@@ -136,7 +136,7 @@ public class ScriptsBrowsingScreen extends BrowsingScreen {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new ScriptsBrowsingScreen());
+        minecraft.gui.setScreen(new ScriptsBrowsingScreen());
     }
 
     protected class FolderElement extends ModuleElement {
@@ -229,9 +229,9 @@ public class ScriptsBrowsingScreen extends BrowsingScreen {
 
         @Override
         public void onClick(double mouseX, double mouseY, int button) {
-//            mc.setScreenAndShow(new DownloadScriptScreenOld());
+//            mc.gui.setScreen(new DownloadScriptScreenOld());
             if (button == 0)
-                mc.setScreenAndShow(new DownloadScriptScreen());
+                mc.gui.setScreen(new DownloadScriptScreen());
         }
     }
 
@@ -369,14 +369,14 @@ public class ScriptsBrowsingScreen extends BrowsingScreen {
                 String preText = newModule.formatted(moduleId);
                 FileValidationUtils.quickWrite(file, preText);
             }
-            mc.setScreenAndShow(new ClickScriptIDE(file));
+            mc.gui.setScreen(new ClickScriptIDE(file));
         }
 
         public static void createScriptWithPretext(String moduleId, String pretext) {
             File file = new File(parentFolder + File.separator + moduleId + ".ccs");
             if (!file.exists())
                 FileValidationUtils.quickWrite(file, pretext);
-            mc.setScreenAndShow(new ClickScriptIDE(file));
+            mc.gui.setScreen(new ClickScriptIDE(file));
         }
 
         @Override

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/profiles/DownloadProfileScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/profiles/DownloadProfileScreen.java
@@ -49,7 +49,7 @@ public class DownloadProfileScreen extends AnimatedBase {
                     fillRoundRect(context, b.x, b.y, b.width, b.height, r, c1);
                     drawCenteredText(context, "<- Go Back", b.x + b.width / 2, b.y + (b.height - 7) / 2, false);
                 })
-                .onPress(button -> mc.execute(() -> mc.setScreenAndShow(new ProfilesScreen())))
+                .onPress(button -> mc.execute(() -> mc.gui.setScreen(new ProfilesScreen())))
                 .build()
         );
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/profiles/ProfilesScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/profiles/ProfilesScreen.java
@@ -49,7 +49,7 @@ public class ProfilesScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new ProfilesScreen());
+        minecraft.gui.setScreen(new ProfilesScreen());
     }
 
     private static class ProfileSelect extends ModuleElement {
@@ -107,7 +107,7 @@ public class ProfilesScreen extends DefaultBase {
             else {
                 while (system.profiles.hasProfile(profileId))
                     system.profiles.deleteProfile(profileId);
-                mc.setScreenAndShow(new ProfilesScreen());
+                mc.gui.setScreen(new ProfilesScreen());
             }
             super.mouseClicked(mouseX, mouseY, button);
         }
@@ -135,7 +135,7 @@ public class ProfilesScreen extends DefaultBase {
                             .replace(' ', '-')
                             .replaceAll("[^a-z_-]", "");
                     system.profiles.switchProfile(name);
-                    mc.setScreenAndShow(new ProfilesScreen());
+                    mc.gui.setScreen(new ProfilesScreen());
                 }
                 return true;
             }
@@ -190,7 +190,7 @@ public class ProfilesScreen extends DefaultBase {
         @Override
         public void mouseClicked(double mouseX, double mouseY, int button) {
             if (isHovered((int)mouseX, (int)mouseY)) {
-                mc.setScreenAndShow(new DownloadProfileScreen());
+                mc.gui.setScreen(new DownloadProfileScreen());
             }
             super.mouseClicked(mouseX, mouseY, button);
         }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/scripts/ClickScriptIDE.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/scripts/ClickScriptIDE.java
@@ -389,7 +389,7 @@ public class ClickScriptIDE extends DefaultBase {
                 ReloadCommand.reload();
 
                 if (mc.gui.screen() instanceof ScriptsBrowsingScreen) {
-                    mc.setScreenAndShow(new ScriptsBrowsingScreen());
+                    mc.gui.setScreen(new ScriptsBrowsingScreen());
                 }
             } catch (Exception ex) {
                 system.printErr("Error: IDE failed to save script");
@@ -412,6 +412,6 @@ public class ClickScriptIDE extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        mc.setScreenAndShow(new ClickScriptIDE(currentFile));
+        mc.gui.setScreen(new ClickScriptIDE(currentFile));
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/scripts/DownloadScriptScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/scripts/DownloadScriptScreen.java
@@ -149,7 +149,7 @@ public class DownloadScriptScreen extends AnimatedBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new DownloadScriptScreen());
+        minecraft.gui.setScreen(new DownloadScriptScreen());
     }
 
     public class FilterButton extends GuiElement {

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/AdvancedSettingScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/AdvancedSettingScreen.java
@@ -26,7 +26,7 @@ public class AdvancedSettingScreen extends DefaultBase {
 
                 system.scheduler.runDelayedTask(() -> mc.execute(() -> {
                     if (setting.getVal() && PlayerUtils.valid()) {
-                        mc.setScreenAndShow(new OverviewScreen());
+                        mc.gui.setScreen(new OverviewScreen());
                     }
                 }), 200);
             })
@@ -113,7 +113,7 @@ public class AdvancedSettingScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new AdvancedSettingScreen());
+        minecraft.gui.setScreen(new AdvancedSettingScreen());
         ClickCrystals.config.saveKeybinds();
         ClickCrystals.config.save();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/InfoScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/InfoScreen.java
@@ -90,6 +90,6 @@ public class InfoScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new InfoScreen());
+        minecraft.gui.setScreen(new InfoScreen());
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/KeybindScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/KeybindScreen.java
@@ -71,7 +71,7 @@ public class KeybindScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new KeybindScreen());
+        minecraft.gui.setScreen(new KeybindScreen());
         ClickCrystals.config.saveKeybinds();
         ClickCrystals.config.save();
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/SettingScreen.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/screens/settings/SettingScreen.java
@@ -58,7 +58,7 @@ public class SettingScreen extends DefaultBase {
 
     @Override
     public void resize(int width, int height) {
-        minecraft.setScreenAndShow(new SettingScreen());
+        minecraft.gui.setScreen(new SettingScreen());
     }
 
     @Override
@@ -104,7 +104,7 @@ public class SettingScreen extends DefaultBase {
 
     public static class ScreenShortcut extends ShortCut {
         public ScreenShortcut(String title, String details, int x, int y, Screen destination, BooleanSupplier check) {
-            super(title, details, x, y, () -> mc.execute(() -> mc.setScreenAndShow(destination)), check);
+            super(title, details, x, y, () -> mc.execute(() -> mc.gui.setScreen(destination)), check);
         }
     }
 

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/AutoRespawn.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/AutoRespawn.java
@@ -32,7 +32,7 @@ public class AutoRespawn extends Module implements Listener {
 
         if (e.getScreen() instanceof DeathScreen) {
             mc.player.respawn();
-            mc.setScreenAndShow((Screen)null);
+            mc.gui.setScreen((Screen)null);
         }
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/MouseTaper.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/MouseTaper.java
@@ -113,7 +113,7 @@ public class MouseTaper extends ListenerModule {
             system.cameraRotator.unlockCursor();
 
             if (reopenOnDisable.getVal() && mc.gui.screen() == null) {
-                mc.setScreenAndShow(new ModuleEditScreen(this));
+                mc.gui.setScreen(new ModuleEditScreen(this));
             }
         }
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/Tunnel3x3.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/misc/Tunnel3x3.java
@@ -105,7 +105,7 @@ public class Tunnel3x3 extends ListenerModule {
         if (mc != null && mc.options != null) {
             mc.options.keyAttack.setDown(false);
             if (reopenOnDisable.getVal() && mc.gui.screen() == null) {
-                mc.setScreenAndShow(new ModuleEditScreen(this));
+                mc.gui.setScreen(new ModuleEditScreen(this));
             }
         }
     }

--- a/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/InteractionUtils.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/util/minecraft/InteractionUtils.java
@@ -97,7 +97,7 @@ public final class InteractionUtils implements Global {
     public static void toggleInventory(boolean toggle) {
         if (toggle) {
             if (mc.gui.screen() == null)
-                mc.execute(() -> mc.setScreenAndShow(new InventoryScreen(PlayerUtils.player())));
+                mc.execute(() -> mc.gui.setScreen(new InventoryScreen(PlayerUtils.player())));
         }
         else {
             if (mc.gui.screen() instanceof InventoryScreen inv)
@@ -125,7 +125,7 @@ public final class InteractionUtils implements Global {
             mc.execute(inv::onClose);
         }
         else {
-            mc.execute(() -> mc.setScreenAndShow(new InventoryScreen(PlayerUtils.player())));
+            mc.execute(() -> mc.gui.setScreen(new InventoryScreen(PlayerUtils.player())));
         }
     }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Every ClickCrystals screen that opens another screen goes through `Minecraft#setScreenAndShow`, which does two things: it swaps the screen through `Gui#setScreen`, and then calls `renderFrame` right there, outside of the normal render loop. That forced frame is drawn in the middle of the swap, and that is the flash you see on every screen change.

## Related issues

None.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.
