### PR TITLE
Keep the command prefix out of the keyboard layout

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/keybinds/Keybind.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/keybinds/Keybind.java
@@ -92,6 +92,11 @@ public class Keybind implements Global {
     }
 
     public String getKeyName() {
+        // glfwGetKeyName renames printable keys after the system layout, key code stays put
+        if (key >= GLFW.GLFW_KEY_APOSTROPHE && key <= GLFW.GLFW_KEY_GRAVE_ACCENT) {
+            return String.valueOf((char)key).toLowerCase();
+        }
+
         String name = GLFW.glfwGetKeyName(key, 32);
         if (name == null) {
             name = EXTRAS.getOrDefault(key, "NONE");


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`Keybind#getKeyName` resolved the command prefix through `glfwGetKeyName`, which names a key after the active operating system keyboard layout. The default prefix is bound to `GLFW_KEY_COMMA`, so on any layout that does not put `,` on that key the prefix reported itself as whichever letter the layout puts there instead.

Chat only ever compares the prefix against the characters a user typed, so the prefix no longer matched what people wrote: every ClickCrystals command was skipped by the mixin and sent to the server as a public chat message. In reverse, ordinary messages starting with that letter were swallowed and dispatched as commands.

Printable GLFW key codes already are their character, so those are now resolved straight from the key code and `glfwGetKeyName` is kept only as the fallback for the remaining keys. The prefix is the same character on every keyboard layout.

## Related issues

None open for this.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.
