### PR TITLE
Answer blocked resource packs on the client thread

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/events/events/networking/PacketReceiveEvent.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/events/networking/PacketReceiveEvent.java
@@ -2,20 +2,27 @@ package io.github.itzispyder.clickcrystals.events.events.networking;
 
 import io.github.itzispyder.clickcrystals.events.Cancellable;
 import io.github.itzispyder.clickcrystals.events.Event;
+import net.minecraft.network.PacketListener;
 import net.minecraft.network.protocol.Packet;
 
 public class PacketReceiveEvent extends Event implements Cancellable {
 
     private final Packet<?> packet;
+    private final PacketListener listener;
     private boolean cancelled;
 
-    public PacketReceiveEvent(Packet<?> packet) {
+    public PacketReceiveEvent(Packet<?> packet, PacketListener listener) {
         this.packet = packet;
+        this.listener = listener;
         this.cancelled = false;
     }
 
     public Packet<?> getPacket() {
         return packet;
+    }
+
+    public PacketListener getListener() {
+        return listener;
     }
 
     @Override

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
@@ -1,7 +1,6 @@
 package io.github.itzispyder.clickcrystals.mixins;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -12,9 +11,6 @@ public interface AccessorMinecraftClient {
 
     @Accessor("crosshairPickEntity")
     Entity accessTargetedEntity();
-
-    @Invoker("setScreenAndShow")
-    void invokeSetScreenAndShow(Screen screen);
 
     @Invoker("startAttack")
     @SuppressWarnings("all")

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinConnection.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinConnection.java
@@ -32,15 +32,16 @@ public abstract class MixinConnection implements Global {
 
     @Inject(method = "genericsFtw", at = @At("HEAD"), cancellable = true)
     private static void onPacketRead(Packet<?> packet, PacketListener listener, CallbackInfo ci) {
-        if (PlayerUtils.invalid())
-            return;
+        if (PlayerUtils.valid()) {
+            if (packet instanceof ClientboundLoginFinishedPacket) {
+                system.eventBus.pass(new GameJoinEvent());
+            }
+            if (packet instanceof ClientboundDamageEventPacket p) {
+                system.eventBus.pass(new EntityDamageEvent(p));
+            }
+        }
 
-        if (packet instanceof ClientboundLoginFinishedPacket) {
-            system.eventBus.pass(new GameJoinEvent());
-        }
-        if (packet instanceof ClientboundDamageEventPacket p) {
-            system.eventBus.pass(new EntityDamageEvent(p));
-        }
-        system.eventBus.passWithCallbackInfo(ci, new PacketReceiveEvent(packet));
+        // passed on with no player around too, the client still gets packets while configuring
+        system.eventBus.passWithCallbackInfo(ci, new PacketReceiveEvent(packet, listener));
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinGui.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinGui.java
@@ -19,8 +19,7 @@ public abstract class MixinGui implements Global {
 
         if (event.isCancelled()) {
             ci.cancel();
-            AccessorMinecraftClient mc = (AccessorMinecraftClient) this;
-            mc.invokeSetScreenAndShow(null);
+            mc.gui.setScreen(null);
         }
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/optimization/NoResPack.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/optimization/NoResPack.java
@@ -6,7 +6,7 @@ import io.github.itzispyder.clickcrystals.events.events.networking.PacketReceive
 import io.github.itzispyder.clickcrystals.modules.Categories;
 import io.github.itzispyder.clickcrystals.modules.Module;
 import io.github.itzispyder.clickcrystals.util.minecraft.ChatUtils;
-import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
+import net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl;
 import net.minecraft.network.protocol.common.ClientboundResourcePackPushPacket;
 import net.minecraft.network.protocol.common.ServerboundResourcePackPacket;
 import net.minecraft.network.protocol.common.ServerboundResourcePackPacket.Action;
@@ -31,22 +31,25 @@ public class NoResPack extends Module implements Listener {
 
     @EventHandler
     private void onResourceReceive(PacketReceiveEvent e) {
-        if (!(e.getPacket() instanceof ClientboundResourcePackPushPacket packet) || PlayerUtils.invalid())
+        // packs are pushed while configuring too, so the listener is answered, not the player
+        if (!(e.getPacket() instanceof ClientboundResourcePackPushPacket packet)
+                || !(e.getListener() instanceof ClientCommonPacketListenerImpl listener))
             return;
 
         // drop the pack (never download it), but spoof the full accept/load handshake so the
         // server thinks we loaded it and doesn't hang or kick us off forced packs
         e.setCancelled(true);
         UUID id = packet.id();
-        respond(id, Action.ACCEPTED);
-        respond(id, Action.DOWNLOADED);
-        respond(id, Action.SUCCESSFULLY_LOADED);
+        respond(listener, id, Action.ACCEPTED);
+        respond(listener, id, Action.DOWNLOADED);
+        respond(listener, id, Action.SUCCESSFULLY_LOADED);
 
+        // packets are read on the network thread, so the chat line waits for the client one
         String status = packet.required() ? "forced" : "suggested";
-        ChatUtils.sendPrefixMessage("Blocked 1 " + status + " resource pack");
+        mc.execute(() -> ChatUtils.sendPrefixMessage("Blocked 1 " + status + " resource pack"));
     }
 
-    private void respond(UUID id, Action action) {
-        PlayerUtils.player().connection.send(new ServerboundResourcePackPacket(id, action));
+    private void respond(ClientCommonPacketListenerImpl listener, UUID id, Action action) {
+        listener.send(new ServerboundResourcePackPacket(id, action));
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

> Stacked on #152, which has to be merged first. `no-server-packs` cannot even be tested without it, since `no-load-screen` drops the connection on join. Once #152 is merged this diff is only the packet event change.

`no-server-packs` never blocked anything, and the module could also break the client when it did run.

`MixinConnection` dropped every `PacketReceiveEvent` while `PlayerUtils.invalid()`, but servers push their pack during the configuration phase, before the player exists. The module listened for a packet event that was never passed on, so the pack was downloaded and applied anyway.

Passing the event with no player around means the module can no longer answer through `PlayerUtils.player().connection`, so `PacketReceiveEvent` now carries the `PacketListener` the packet was read on. `ClientCommonPacketListenerImpl` owns the connection in both the configuration and the play phase, and the spoofed `ACCEPTED` / `DOWNLOADED` / `SUCCESSFULLY_LOADED` handshake goes back on it.

`GameJoinEvent` and `EntityDamageEvent` keep their old player check, so nothing else sees new events.

The pack is still cancelled straight away on the network thread, and only the chat line is handed to the client thread, since `ChatUtils` writes into the chat hud.

## Related issues

None open for this.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.

