### PR TITLE
Close the screen through the gui when a screen change is cancelled

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
@@ -1,7 +1,6 @@
 package io.github.itzispyder.clickcrystals.mixins;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -12,9 +11,6 @@ public interface AccessorMinecraftClient {
 
     @Accessor("crosshairPickEntity")
     Entity accessTargetedEntity();
-
-    @Invoker("setScreenAndShow")
-    void invokeSetScreenAndShow(Screen screen);
 
     @Invoker("startAttack")
     @SuppressWarnings("all")

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinGui.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinGui.java
@@ -19,8 +19,7 @@ public abstract class MixinGui implements Global {
 
         if (event.isCancelled()) {
             ci.cancel();
-            AccessorMinecraftClient mc = (AccessorMinecraftClient) this;
-            mc.invokeSetScreenAndShow(null);
+            mc.gui.setScreen(null);
         }
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

`MixinGui` mixes into `Gui`, but the cancelled branch of `setScreen` still cast `this` to `AccessorMinecraftClient`, which mixes into `Minecraft`. Any cancelled screen change therefore threw:

```
java.lang.ClassCastException: class net.minecraft.client.gui.Gui cannot be cast to class io.github.itzispyder.clickcrystals.mixins.AccessorMinecraftClient
	at net.minecraft.client.gui.Gui.handler$zbd000$clickcrystals$setScreen(Gui.java:541)
	at net.minecraft.client.Minecraft.setScreenAndShow(Minecraft.java:2293)
	at net.minecraft.client.multiplayer.ClientPacketListener.startWaitingForNewLevel(ClientPacketListener.java:1630)
	at net.minecraft.client.multiplayer.ClientPacketListener.handleLogin(ClientPacketListener.java:567)
```

`no-load-screen` cancels the `LevelLoadingScreen`, and that screen is set while the login packet is being handled, so the exception landed inside packet handling and dropped the connection. With the module on, joining a server failed every time.

The cancelled branch now goes through `mc.gui.setScreen(null)`, the same call the rest of the mod uses to swap screens. `setScreenAndShow` was the only user of the `AccessorMinecraftClient` invoker, so that invoker is gone too.

## Related issues

None open for this.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.

