### PR TITLE
Fix join crash, blocked resource packs, staff join spam and command prefix

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/events/events/networking/PacketReceiveEvent.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/events/networking/PacketReceiveEvent.java
@@ -2,20 +2,27 @@ package io.github.itzispyder.clickcrystals.events.events.networking;
 
 import io.github.itzispyder.clickcrystals.events.Cancellable;
 import io.github.itzispyder.clickcrystals.events.Event;
+import net.minecraft.network.PacketListener;
 import net.minecraft.network.protocol.Packet;
 
 public class PacketReceiveEvent extends Event implements Cancellable {
 
     private final Packet<?> packet;
+    private final PacketListener listener;
     private boolean cancelled;
 
-    public PacketReceiveEvent(Packet<?> packet) {
+    public PacketReceiveEvent(Packet<?> packet, PacketListener listener) {
         this.packet = packet;
+        this.listener = listener;
         this.cancelled = false;
     }
 
     public Packet<?> getPacket() {
         return packet;
+    }
+
+    public PacketListener getListener() {
+        return listener;
     }
 
     @Override

--- a/src/main/java/io/github/itzispyder/clickcrystals/events/listeners/NetworkEventListener.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/events/listeners/NetworkEventListener.java
@@ -26,12 +26,16 @@ import net.minecraft.network.protocol.login.ServerboundHelloPacket;
 import net.minecraft.network.protocol.login.ServerboundKeyPacket;
 
 import java.net.URI;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static io.github.itzispyder.clickcrystals.ClickCrystals.commandPrefix;
 import static io.github.itzispyder.clickcrystals.ClickCrystals.config;
 
 public class NetworkEventListener implements Listener {
+
+    private final Set<UUID> seenPlayers = ConcurrentHashMap.newKeySet();
 
     @EventHandler
     public void onPacketSend(PacketSendEvent e) {
@@ -69,6 +73,7 @@ public class NetworkEventListener implements Listener {
     public void onGameLeave(GameLeaveEvent e) {
         try {
             Notification.clearNotifications();
+            seenPlayers.clear();
             BulletinBoard.request();
             system.cameraRotator.closeAllTickets();
         }
@@ -84,6 +89,11 @@ public class NetworkEventListener implements Listener {
                 for (ClientboundPlayerInfoUpdatePacket.Entry entry : packet.newEntries()) {
                     UUID id = entry.profile().id();
                     String name = entry.profile().name();
+
+                    // servers re-add the same players on tab list refreshes and lobby switches
+                    if (!seenPlayers.add(id)) {
+                        continue;
+                    }
 
                     if (ClickCrystals.info.getOwner(id) != null) {
                         Notification.create()

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/AccessorMinecraftClient.java
@@ -1,7 +1,6 @@
 package io.github.itzispyder.clickcrystals.mixins;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.entity.Entity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
@@ -12,9 +11,6 @@ public interface AccessorMinecraftClient {
 
     @Accessor("crosshairPickEntity")
     Entity accessTargetedEntity();
-
-    @Invoker("setScreenAndShow")
-    void invokeSetScreenAndShow(Screen screen);
 
     @Invoker("startAttack")
     @SuppressWarnings("all")

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinConnection.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinConnection.java
@@ -32,15 +32,16 @@ public abstract class MixinConnection implements Global {
 
     @Inject(method = "genericsFtw", at = @At("HEAD"), cancellable = true)
     private static void onPacketRead(Packet<?> packet, PacketListener listener, CallbackInfo ci) {
-        if (PlayerUtils.invalid())
-            return;
+        if (PlayerUtils.valid()) {
+            if (packet instanceof ClientboundLoginFinishedPacket) {
+                system.eventBus.pass(new GameJoinEvent());
+            }
+            if (packet instanceof ClientboundDamageEventPacket p) {
+                system.eventBus.pass(new EntityDamageEvent(p));
+            }
+        }
 
-        if (packet instanceof ClientboundLoginFinishedPacket) {
-            system.eventBus.pass(new GameJoinEvent());
-        }
-        if (packet instanceof ClientboundDamageEventPacket p) {
-            system.eventBus.pass(new EntityDamageEvent(p));
-        }
-        system.eventBus.passWithCallbackInfo(ci, new PacketReceiveEvent(packet));
+        // passed on with no player around too, the client still gets packets while configuring
+        system.eventBus.passWithCallbackInfo(ci, new PacketReceiveEvent(packet, listener));
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinGui.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/mixins/MixinGui.java
@@ -19,8 +19,7 @@ public abstract class MixinGui implements Global {
 
         if (event.isCancelled()) {
             ci.cancel();
-            AccessorMinecraftClient mc = (AccessorMinecraftClient) this;
-            mc.invokeSetScreenAndShow(null);
+            mc.gui.setScreen(null);
         }
     }
 }

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/keybinds/Keybind.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/keybinds/Keybind.java
@@ -92,6 +92,11 @@ public class Keybind implements Global {
     }
 
     public String getKeyName() {
+        // glfwGetKeyName renames printable keys after the system layout, key code stays put
+        if (key >= GLFW.GLFW_KEY_APOSTROPHE && key <= GLFW.GLFW_KEY_GRAVE_ACCENT) {
+            return String.valueOf((char)key).toLowerCase();
+        }
+
         String name = GLFW.glfwGetKeyName(key, 32);
         if (name == null) {
             name = EXTRAS.getOrDefault(key, "NONE");

--- a/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/optimization/NoResPack.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/modules/modules/optimization/NoResPack.java
@@ -6,7 +6,7 @@ import io.github.itzispyder.clickcrystals.events.events.networking.PacketReceive
 import io.github.itzispyder.clickcrystals.modules.Categories;
 import io.github.itzispyder.clickcrystals.modules.Module;
 import io.github.itzispyder.clickcrystals.util.minecraft.ChatUtils;
-import io.github.itzispyder.clickcrystals.util.minecraft.PlayerUtils;
+import net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl;
 import net.minecraft.network.protocol.common.ClientboundResourcePackPushPacket;
 import net.minecraft.network.protocol.common.ServerboundResourcePackPacket;
 import net.minecraft.network.protocol.common.ServerboundResourcePackPacket.Action;
@@ -31,22 +31,25 @@ public class NoResPack extends Module implements Listener {
 
     @EventHandler
     private void onResourceReceive(PacketReceiveEvent e) {
-        if (!(e.getPacket() instanceof ClientboundResourcePackPushPacket packet) || PlayerUtils.invalid())
+        // packs are pushed while configuring too, so the listener is answered, not the player
+        if (!(e.getPacket() instanceof ClientboundResourcePackPushPacket packet)
+                || !(e.getListener() instanceof ClientCommonPacketListenerImpl listener))
             return;
 
         // drop the pack (never download it), but spoof the full accept/load handshake so the
         // server thinks we loaded it and doesn't hang or kick us off forced packs
         e.setCancelled(true);
         UUID id = packet.id();
-        respond(id, Action.ACCEPTED);
-        respond(id, Action.DOWNLOADED);
-        respond(id, Action.SUCCESSFULLY_LOADED);
+        respond(listener, id, Action.ACCEPTED);
+        respond(listener, id, Action.DOWNLOADED);
+        respond(listener, id, Action.SUCCESSFULLY_LOADED);
 
+        // packets are read on the network thread, so the chat line waits for the client one
         String status = packet.required() ? "forced" : "suggested";
-        ChatUtils.sendPrefixMessage("Blocked 1 " + status + " resource pack");
+        mc.execute(() -> ChatUtils.sendPrefixMessage("Blocked 1 " + status + " resource pack"));
     }
 
-    private void respond(UUID id, Action action) {
-        PlayerUtils.player().connection.send(new ServerboundResourcePackPacket(id, action));
+    private void respond(ClientCommonPacketListenerImpl listener, UUID id, Action action) {
+        listener.send(new ServerboundResourcePackPacket(id, action));
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

Four client fixes, one commit each. Replaces #150, #151, #152 and #153.

- **Join crash with `no-load-screen`** - `MixinGui` cast `this` to `AccessorMinecraftClient`, which mixes into `Minecraft`, so every cancelled screen change threw a `ClassCastException` inside packet handling and dropped the connection. Now uses `mc.gui.setScreen(null)`. That invoker was its only user, so it is gone.
- **`no-server-packs` blocked nothing** - packs are pushed during the configuration phase, but `MixinConnection` dropped `PacketReceiveEvent` while there was no player. The event is now passed anyway and carries the `PacketListener`, which the module answers the handshake on. `GameJoinEvent` and `EntityDamageEvent` keep their player check.
- **Staff join notification spam** - servers re-send `ADD_PLAYER` on tab list refreshes and lobby switches. `NetworkEventListener` now announces each id once and forgets them on game leave.
- **Custom commands sent as chat** - `getKeyName` ran the prefix through `glfwGetKeyName`, which renames printable keys after the system keyboard layout. Printable key codes are already their character, so those are returned directly.

## Related issues

None open for these.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [x] I have added comments to my code in more complex areas.
- [x] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.
