### PR TITLE
Stop the scroll panels from scrolling past their content

### DIFF
--- a/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/common/interactive/ScrollPanelElement.java
+++ b/src/main/java/io/github/itzispyder/clickcrystals/gui/elements/common/interactive/ScrollPanelElement.java
@@ -81,6 +81,12 @@ public class ScrollPanelElement extends GuiElement {
         child.scrollOnPanel(this, 0);
     }
 
+    @Override
+    public void clearChildren() {
+        super.clearChildren();
+        recalculatePositions();
+    }
+
     public void updateBounds(GuiElement child) {
         if (child.y < limitTop) {
             limitTop = child.y;


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature

## Description

The scroll panels let you scroll far past the content. Switch from a long category like rendering to a short one like anchoring, or narrow the list down with the search bar, and the bar still drags down into a big empty area below the last entry.

## Related issues

None, ran into it while switching module categories.

# Checklist:

- [x] My code follows the style guidelines of ItziSpyder(ImproperIssues).
- [ ] I have added comments to my code in more complex areas.
- [ ] I have tested the code in both development and production environments.
- [x] I have joined  the [ClickCrystals]((https://discord.com/invite/tMaShNzNtP)) Discord.
